### PR TITLE
Frontpagetables

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -81,11 +81,14 @@
 				
 				
 			</div>
-			<div style="margin-top:10px">
+			</div>
+			</div>
+			<div align="center">
+
 					<h3><i class="icon-info-sign"></i> DATABASE <em>STATS</em></h3>
-					<%= image_tag 'database_stats.png', alt: "Stats for the BETYdb database" %>
+					<%= image_tag 'database_stats.png', width:"750", alt: "Stats for the BETYdb database" %>
 				</div>
-			<!-- InstanceEndEditable --> </div>
-	</div>
+			<!-- InstanceEndEditable --> 
+	
 	<!-- container --> 
 </div>


### PR DESCRIPTION
Adds image tag for image from f60d23abf82456b89c677120e793e83ac26ef45c, replacing static tables on the frontpage. Currently image is static and not regenerated.
