### PR TITLE
added notes to limit fields returned via API requsts to species and site...

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -29,6 +29,18 @@ class Site < ActiveRecord::Base
     end
   }
 
+=begin
+do json / xml api 
+city
+state
+country
+lat
+lon
+sitename
+greenhouse
+notes
+=end
+
   comma do
     id
     city

--- a/app/models/specie.rb
+++ b/app/models/specie.rb
@@ -17,10 +17,14 @@ class Specie < ActiveRecord::Base
   scope :by_letter, lambda { |letter| where('genus like ?', letter + "%") }
   scope :sorted_order, lambda { |order| order(order).includes(SEARCH_INCLUDES) }
   scope :search, lambda { |search| where(simple_search(search)) }
-
+=begin
+do json / xml api fields to return
+genus
+species
+scientificname
+=end
   comma do |f|
     f.id
-    f.spcd
     f.genus
     f.species
     f.scientificname
@@ -28,85 +32,6 @@ class Specie < ActiveRecord::Base
     f.notes
     f.created_at
     f.updated_at
-    f.AcceptedSymbol
-    f.SynonymSymbol
-    f.Symbol
-    f.PLANTS_Floristic_Area
-    f.State
-    f.Category
-    f.Family
-    f.FamilySymbol
-    f.FamilyCommonName
-    f.xOrder
-    f.SubClass
-    f.Class
-    f.SubDivision
-    f.Division
-    f.SuperDivision
-    f.SubKingdom
-    f.Kingdom
-    f.ITIS_TSN
-    f.Duration
-    f.GrowthHabit
-    f.NativeStatus
-    f.NationalWetlandIndicatorStatus
-    f.RegionalWetlandIndicatorStatus
-    f.ActiveGrowthPeriod
-    f.AfterHarvestRegrowthRate
-    f.Bloat
-    f.C2N_Ratio
-    f.CoppicePotential
-    f.FallConspicuous
-    f.FireResistance
-    f.FoliageTexture
-    f.GrowthForm
-    f.GrowthRate
-    f.MaxHeight20Yrs
-    f.MatureHeight
-    f.KnownAllelopath
-    f.LeafRetention
-    f.Lifespan
-    f.LowGrowingGrass
-    f.NitrogenFixation
-    f.ResproutAbility
-    f.AdaptedCoarseSoils
-    f.AdaptedMediumSoils
-    f.AdaptedFineSoils
-    f.AnaerobicTolerance
-    f.CaCO3Tolerance
-    f.ColdStratification
-    f.DroughtTolerance
-    f.FertilityRequirement
-    f.FireTolerance
-    f.MinFrostFreeDays
-    f.HedgeTolerance
-    f.MoistureUse
-    f.pH_Minimum
-    f.pH_Maximum
-    f.Min_PlantingDensity
-    f.Max_PlantingDensity
-    f.Precipitation_Minimum
-    f.Precipitation_Maximum
-    f.RootDepthMinimum
-    f.SalinityTolerance
-    f.ShadeTolerance
-    f.TemperatureMinimum
-    f.BloomPeriod
-    f.CommercialAvailability
-    f.FruitSeedPeriodBegin
-    f.FruitSeedPeriodEnd
-    f.Propogated_by_BareRoot
-    f.Propogated_by_Bulbs
-    f.Propogated_by_Container
-    f.Propogated_by_Corms
-    f.Propogated_by_Cuttings
-    f.Propogated_by_Seed
-    f.Propogated_by_Sod
-    f.Propogated_by_Sprigs
-    f.Propogated_by_Tubers
-    f.Seeds_per_Pound
-    f.SeedSpreadRate
-    f.SeedlingVigor
   end
 
 


### PR DESCRIPTION
I've listed the subset of fields that should be returned to the api. For other tables, the `comma do` definitions are okay, though I am not certain if we ever need to return the foreign keys, or the created_at and updated_at fields.
