### PR TITLE
Send email on new signup RM-1707

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,36 +47,11 @@ class UsersController < ApplicationController
     page_access_level = ["", "Administrator", "Manager", "Creator", "Viewer"]
     access_level = ["", "Restricted", "Internal EBI & Collaborators", "External Researchers", "Public"]
 
-    if params[:user][:page_access_level].to_i != 4 or params[:user][:access_level].to_i != 3
-      xml = "<issue>"
-      xml += "<project name='BETY-db' id='1'/>"
-      xml += "<tracker name='Bug' id='1'/>"
-      xml += "<status name='New' id='1'/>"
-      xml += "<priority name='Normal' id='4'/>"
-      xml += "<author name='BETY Bug Report' id='32'/>"
-      xml += "<assigned_to id='3'/>"
-      xml += "<subject>Access request for #{@user.name.encode("ascii", invalid: :replace, undef: :replace)} (#{@user.login})</subject>"
-      xml += "<description>https://www.betydb.org/users/#{@user.id}/edit\n"
-      xml += "\n"
-      xml += "#{@user.name.encode("ascii", invalid: :replace, undef: :replace)} (#{@user.login}) has requested a non-default access level.\n"
-      xml += "Page_access_level: #{page_access_level[params[:user][:page_access_level].to_i]}\n"
-      xml += "Access_level: #{access_level[params[:user][:access_level].to_i]}\n"
-      xml += "\n"
-      xml += "Reason: #{params[:access_level_reason]}\n"
-      xml += "</description>"
-      xml += "</issue>'"
-
-      uri = URI.parse("https://ebi-forecast.igb.illinois.edu/redmine/projects/bety-db/issues.xml")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-
-      request = Net::HTTP::Post.new(uri.request_uri)
-      request.basic_auth "betybug", "ch#pRUr9"
-      request.body = xml
-      request.content_type = "application/xml"
-      response = http.request(request)
-    end
     if success && @user.errors.empty?
+      if params[:user][:page_access_level].to_i < 4 or params[:user][:access_level].to_i < 3
+        ContactMailer::admin_approval(params[:user]).deliver
+      end
+      ContactMailer::signup_email(@user).deliver
       # Protects against session fixation attacks, causes request forgery
       # protection if visitor resubmits an earlier form using back
       # button. Uncomment if you understand the tradeoffs.

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -7,4 +7,35 @@ class ContactMailer < ActionMailer::Base
          :from => email_params[:name] + " <" + email_params[:address] + ">",
          :date => Time.now)
   end
+
+  def signup_email(user)
+  	@user = user
+  	@url = root_path
+
+  	email_from = "#{@user[:name]} <#{@user[:email]}>"
+	email_to = User.where(page_access_level: 1).map! do |attributes|
+		"#{attributes.name} < #{attributes.email}>"
+	end
+	email_to << email_from
+
+    mail(:to => email_to,
+         :from => email_from,
+         :subject => "[BETY] New user signup",
+         :date => Time.now)
+  end
+
+  def admin_approval(user)
+  	@user = user
+  	@url = root_path
+
+  	email_from = "#{@user[:name]} <#{@user[:email]}>"
+	email_to = User.where(page_access_level: 1).map! do |attributes|
+		"#{attributes.name} < #{attributes.email}>"
+	end
+
+    mail(:to => email_to,
+         :from => email_from,
+         :subject => "[BETY] Access request",
+         :date => Time.now)
+  end
 end

--- a/app/views/contact_mailer/admin_approval.html.erb
+++ b/app/views/contact_mailer/admin_approval.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Access request for <%= @user[:name].encode("ascii", invalid: :replace, undef: :replace) %> (<%= @user[:login] %>)</h1>
+    <p>
+    <%= @user[:name].encode("ascii", invalid: :replace, undef: :replace) %> (<%= @user[:login] %>) has
+    requested a non-default access level at <%= @url %>.
+    </p>
+    <table>
+    <tr><th>Page_access_level :</th><td><%= @user[:page_access_level] %></td></tr>
+    <tr><th>Access_level      :</th><td><%= @user[:access_level] %></td></tr>
+    </table>
+  </body>
+</html>

--- a/app/views/contact_mailer/admin_approval.txt.erb
+++ b/app/views/contact_mailer/admin_approval.txt.erb
@@ -1,0 +1,7 @@
+Access request for <%= @user[:name].encode("ascii", invalid: :replace, undef: :replace) %>  (<%= @user[:login] %>)
+
+<%= @user[:name].encode("ascii", invalid: :replace, undef: :replace) %>  (<%= @user[:login] %>) has
+requested a non-default access level level at <%= @url %>.
+
+Page_access_level : <%= @user[:page_access_level] %>
+Access_level      : <%= @user[:access_level] %>

--- a/app/views/contact_mailer/signup_email.html.erb
+++ b/app/views/contact_mailer/signup_email.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Welcome to BETY, <%= @user[:name] %></h1>
+    <p>
+      You have successfully signed up to BETY,
+      your username is: <%= @user[:login] %>.<br>
+    </p>
+    <p>
+      To login to the site, just follow this link: <%= @url %>.
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/app/views/contact_mailer/signup_email.txt.erb
+++ b/app/views/contact_mailer/signup_email.txt.erb
@@ -1,0 +1,9 @@
+Welcome to BETY, <%= @user[:name] %>
+===============================================
+ 
+You have successfully signed up to BETY,
+your username is: <%= @user[:login] %>.
+ 
+To login to the site, just follow this link: <%= @url %>.
+ 
+Thanks for joining and have a great day!


### PR DESCRIPTION
Instead of creating an issue in redmine this will send an email to all
users who are of page_access_level==1 when a new user is created and/or
when the user requests page_access_level < 4 or acces_level < 3.

This will also send an email to the new user.

Make sure to update the database before using this, since all people in
the BETY dump are page_access_level == 1.
