### PR TITLE
fix schema css (redmine #2098)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,8 @@
   <!-- Old CSS -->
   <%= stylesheet_link_tag "scaffold" %>
   <!-- Redesign CSS -->
-  <%= stylesheet_link_tag "schemaSpy", "base", "grid", "layout", "dropdown", "tables", "demo" %>
+  <%= yield :schemaCSS %>
+  <%= stylesheet_link_tag "base", "grid", "layout", "dropdown", "tables", "demo" %>
 </head>
 
 

--- a/app/views/schemas/index.html.erb
+++ b/app/views/schemas/index.html.erb
@@ -1,4 +1,6 @@
-
+<% content_for :schemaCSS do %>
+  <%= stylesheet_link_tag "schemaSpy" %>
+<% end %>
 <script type="text/javascript">jQuery(function(){jQuery(".dataTable").removeClass("dataTable").addClass("table table-striped table-bordered table-hover datatable dataTable");jQuery(".even").removeClass("even");jQuery(".odd").removeClass("odd")});</script>
 <div class='content' style='clear:both;'>
 <div class='container'>


### PR DESCRIPTION
see <a href="https://ebi-forecast.igb.illinois.edu/redmine/issues/2098">redmine #2098</a>
Removed "schemaSpy" from global css inclusion.
