### PR TITLE
redmine 2007 update permissions

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -131,7 +131,7 @@
                 <li><%= link_to "Species", species_index_path %></li>
                 <li><%= link_to "Traits", traits_path %></li>
                 <li><%= link_to "Treatments", treatments_path %></li>
-                <% if current_user != nil && current_user.page_access_level <= 2 %>
+                <% if current_user != nil && current_user.page_access_level <= 1 %>
                 <li><%= link_to "Users", users_path %></li>
                 <% end %>
                 <li><%= link_to "Variables", variables_path %></li>

--- a/lib/authenticated_system.rb
+++ b/lib/authenticated_system.rb
@@ -46,16 +46,7 @@ module AuthenticatedSystem
       # RAILS3 changed below line with second below line. controller_class_name appears to have been removed Rails3
       # controller_class = controller_class_name if controller_class.nil?
       controller_class = "#{controller_name.camelize}Controller" if controller_class.nil?
-      admin_requirement = ["UsersController.ALL",
-                                "PosteriorsController.ALL",
-                                "PosteriorsRunsController.ALL",
-                                "RunsController.ALL",
-                                "LikelihoodsController.ALL",
-                                "ModelsController.ALL",
-                                "InputsRunsController.ALL",
-                                "YieldsviewsController.ALL",
-                                "InputsVariablesController.ALL",
-                                "InputsController.ALL" ]
+      admin_requirement = ["UsersController.ALL"],
       manage_requirement = ["CitationsController.ALL",
                                 "CovariatesController.ALL",
                                 "CultivarsController.ALL",


### PR DESCRIPTION
Small tweak, not the real fix, to allow a manger to create/edit/delete everything except for users. Only those with admin access can see the users page.

@dlebauer this should allow us to give people permission to work with the inputs, but not have to give them admin rights.
