### PR TITLE
fixes redmine 2186

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -4,7 +4,8 @@ Scott Rohde; Carl Crott; Patrick Mulroony; Jeremy Kemball; David LeBauer; Jimmy 
 2014. BETYdb 3.0.4. [doi:10.5281/zenodo.10644](http://dx.doi.org/10.5281/zenodo.10644)
 
 ## Data
-David LeBauer; Michael Dietze; Rob Kooper; Steven Long; Patrick Mulrooney; Gareth Scott Rohde; Dan Wang 2010.
-Biofuel Ecophysiological Traits and Yields Database (BETYdb)
+
+LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang (2010).
+Biofuel Ecophysiological Traits and Yields Database (BETYdb),
 Energy Biosciences Institute, University of Illinois at Urbana-Champaign.
 doi:10.13012/J8H41PB9

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,10 +5,12 @@ class SearchController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   CREDITS = <<CREDITS
-David LeBauer, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang 2010.\ 
-Biofuel Ecophysiological Traits and Yields Database (BETYdb)\
-Energy Biosciences Institute, University of Illinois at Urbana-Champaign.\
-doi:10.13012/J8H41PB9\
+LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang (2010).  \
+Biofuel Ecophysiological Traits and Yields Database (BETYdb), Energy Biosciences Institute, University of Illinois at Urbana-Champaign. \
+doi:10.13012/J8H41PB9 \
+All public data in BETYdb is made available under the Open Data Commons Attribution License (ODC-By) v1.0. \
+You are free to share, create, and adapt its contents. \
+Data with an access_level field and value <= 2 is is not covered by this license but may be available for use with consent.
 CREDITS
   CREDITS.chomp!
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -256,10 +256,14 @@
 				  <div id="google_translate_element"><div class="skiptranslate goog-te-gadget" dir="ltr" style=""><div id=":0.targetLanguage" style="white-space: nowrap; " class="goog-te-gadget-simple"><img src="http://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" style="background-image: url(http://translate.googleapis.com/translate_static/img/te_ctrl3.gif); background-position: -65px 0px; "><span style="vertical-align: middle; "><a class="goog-te-menu-value" href="javascript:void(0)"><span>Select Language</span><img src="http://www.google.com/images/cleardot.gif" width="1" height="1"><span style="border-left-width: 1px; border-left-style: solid; border-left-color: rgb(187, 187, 187); ">​</span><img src="http://www.google.com/images/cleardot.gif" width="1" height="1"><span style="color: rgb(155, 155, 155); ">▼</span></a></span></div></div></div>
 			  </div>
 			  <div class="six columns omega">
-				  <p>David LeBauer; Michael Dietze; Rob Kooper; Steven Long; Patrick Mulrooney; Gareth Scott Rohde; Dan Wang, 2010\
-				    Biofuel Ecophysiological Traits and Yields Database (BETYdb)\
-				    Energy Biosciences Institute, University of Illinois at Urbana-Champaign.\
-				    <a href="https://dx.doi.org/10.13012/J8H41PB9">doi:10.13012/J8H41PB9</a> \
+				  <p>LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang (2010).
+                     <cite>Biofuel Ecophysiological Traits and Yields Database (BETYdb)</cite>,
+                     Energy Biosciences Institute, University of Illinois at Urbana-Champaign.
+                     doi:10.13012/J8H41PB9</p>
+                  <p>All public data in BETYdb is made available under the
+                     <a href="http://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) v1.0.</a>
+                     You are free to share, create, and adapt its contents.
+                     Data with an access_level field and value <= 2 is is not covered by this license but may be available for use with consent.</p>
 				  <p>Copyright © 2010-2014 Energy Biosciences Institute</p>
 			  </div>
 		  </div>

--- a/public/UI_redesign/index.html
+++ b/public/UI_redesign/index.html
@@ -411,11 +411,15 @@
             <div id="google_translate_element"></div>
         </div>
 		<div class="six columns omega">
-		  <p>David LeBauer; Michael Dietze; Rob Kooper; Steven Long; Patrick Mulrooney; Gareth Scott Rohde; Dan Wang, 2010\
-		    Biofuel Ecophysiological Traits and Yields Database (BETYdb)\
-		    Energy Biosciences Institute, University of Illinois at Urbana-Champaign.\
-		    <a href="https://dx.doi.org/10.13012/J8H41PB9">doi:10.1301</a>
-            <p>Copyright &copy; 2010-2012 Energy Biosciences Institute</p>
+			<p>LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang (2010).
+			   <cite>Biofuel Ecophysiological Traits and Yields Database (BETYdb)</cite>,
+			   Energy Biosciences Institute, University of Illinois at Urbana-Champaign.
+			   doi:10.13012/J8H41PB9</p>
+			<p>All public data in BETYdb is made available under the
+			   <a href="http://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) v1.0.</a>
+			   You are free to share, create, and adapt its contents.
+			   Data with an access_level field and value <= 2 is is not covered by this license but may be available for use with consent.</p>
+			<p>Copyright © 2010-2014 Energy Biosciences Institute</p>
         </div>
         <hr />
         <div class="footnotes">     

--- a/public/stylesheets/base.css
+++ b/public/stylesheets/base.css
@@ -282,7 +282,7 @@ em {
 }
 
 cite {
-	font-style: normal;
+	font-style: italic;
 	color: #999999;
 }
 blockquote cite {


### PR DESCRIPTION
 by updating data citation information with datacite record and doi https://ebi-forecast.igb.illinois.edu/redmine/issues/2168

@udaysaraf can you please check the following and then reassign to @gsrohde?
1. new citation information should appear in the header of the csv file downloaded from the search page (e.g. https://www.betydb.org/search.csv?&search=Switchgrass)
2. The footer citation info is updated (see image of old footer below)
   ![image](https://cloud.githubusercontent.com/assets/464871/3990142/757905f6-28c5-11e4-8c62-f9376e4e2e87.png)
3. The public/UI_redesign/index.html is also valid
