### PR TITLE
add IDs to many-many tables

### DIFF
--- a/db/migrate/20150202215147_add_id_many_to_many.rb
+++ b/db/migrate/20150202215147_add_id_many_to_many.rb
@@ -1,14 +1,14 @@
 class AddIdManyToMany < ActiveRecord::Migration
   def self.up
     execute %{
-      ALTER TABLE "citations_sites" ADD "id" serial;
-      ALTER TABLE "citations_treatments" ADD "id" serial;
-      ALTER TABLE "inputs_runs" ADD "id" serial;
-      ALTER TABLE "inputs_variables" ADD "id" serial;
-      ALTER TABLE "managements_treatments" ADD "id" serial;
-      ALTER TABLE "pfts_priors" ADD "id" serial;
-      ALTER TABLE "pfts_species" ADD "id" serial;
-      ALTER TABLE "posteriors_ensembles" ADD "id" serial;
+      ALTER TABLE "citations_sites" ADD "id" bigserial;
+      ALTER TABLE "citations_treatments" ADD "id" bigserial;
+      ALTER TABLE "inputs_runs" ADD "id" bigserial;
+      ALTER TABLE "inputs_variables" ADD "id" bigserial;
+      ALTER TABLE "managements_treatments" ADD "id" bigserial;
+      ALTER TABLE "pfts_priors" ADD "id" bigserial;
+      ALTER TABLE "pfts_species" ADD "id" bigserial;
+      ALTER TABLE "posteriors_ensembles" ADD "id" bigserial;
     }
   end
 

--- a/db/migrate/20150202215147_add_id_many_to_many.rb
+++ b/db/migrate/20150202215147_add_id_many_to_many.rb
@@ -1,0 +1,25 @@
+class AddIdManyToMany < ActiveRecord::Migration
+  def self.up
+    execute %{
+      ALTER TABLE "citations_sites" ADD "id" serial;
+      ALTER TABLE "citations_treatments" ADD "id" serial;
+      ALTER TABLE "inputs_runs" ADD "id" serial;
+      ALTER TABLE "inputs_variables" ADD "id" serial;
+      ALTER TABLE "managements_treatments" ADD "id" serial;
+      ALTER TABLE "pfts_priors" ADD "id" serial;
+      ALTER TABLE "pfts_species" ADD "id" serial;
+      ALTER TABLE "posteriors_ensembles" ADD "id" serial;
+    }
+  end
+
+  def self.down
+    remove_column :citations_sites, :id
+    remove_column :citations_treatments, :id
+    remove_column :inputs_runs, :id
+    remove_column :inputs_variables, :id
+    remove_column :managements_treatments, :id
+    remove_column :pfts_priors, :id
+    remove_column :pfts_species, :id
+    remove_column :posteriors_ensembles, :id
+  end
+end

--- a/fix.many.id.sh
+++ b/fix.many.id.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+DATABASE=${DATABASE:-"bety"}
+OWNER=${OWNER:-"bety"}
+PG_OPT=${PG_OPT:-""}
+MYSITE=${MYSITE:-99}
+
+# list of tables that are many to many relationships
+MANY_TABLES="${MANY_TABLES} citations_sites citations_treatments"
+MANY_TABLES="${MANY_TABLES} formats_variables inputs_runs"
+MANY_TABLES="${MANY_TABLES} inputs_variables"
+MANY_TABLES="${MANY_TABLES} managements_treatments pfts_priors"
+MANY_TABLES="${MANY_TABLES} pfts_species posteriors_ensembles"
+
+ID_RANGE=1000000000
+START_ID=$(( MYSITE * ID_RANGE + 1 ))
+LAST_ID=$(( START_ID + ID_RANGE - 1 ))
+
+for T in ${MANY_TABLES}; do
+  Z=(${T//_/ })
+  X=${Z[0]}
+  X=${X%s}
+  Y=${Z[1]}
+  Y=${Y%s}
+  printf "Fixing %-25s : " "${T}"
+  psql -q -d "${DATABASE}" -c "ALTER TABLE ${T} DISABLE TRIGGER ALL;"
+  WHERE="WHERE (${X}_id >= ${START_ID} AND ${X}_id <= ${LAST_ID}) OR (${Y}_id >= ${START_ID} AND ${Y}_id <= ${LAST_ID})"
+  FIX=$( psql ${PG_OPT} -U ${OWNER} -t -q -d "${DATABASE}" -c "SELECT count(*) FROM ${T} ${WHERE}" | tr -d ' ' )
+  IGN=$( psql ${PG_OPT} -U ${OWNER} -t -q -d "${DATABASE}" -c "SELECT setval('${T}_id_seq', ${START_ID}, false); SELECT setval('${T}_id_seq', (SELECT MAX(id) FROM ${T} WHERE id >= ${START_ID} AND id < ${LAST_ID}), true);" )
+  IGN=$( psql ${PG_OPT} -U ${OWNER} -t -q -d "${DATABASE}" -c "UPDATE $T SET id=nextval('${T}_id_seq') ${WHERE};" )
+  echo "UPDATED ${FIX} records"
+  psql -q -d "${DATABASE}" -c "ALTER TABLE ${T} ENABLE TRIGGER ALL;"
+done


### PR DESCRIPTION
This ID will be used to find those tables that should be synchronized
and what data was entered at what site.

The id's are set to auto increment and will be defaulted to be in the
range of EBI.

The script fix.many.id.sh can be used to fix the auto increment ID to
be in the right range and will try to set the ID's of those that are
entered at the remote site (this is done by looking at the id's of the
elements referenced and see if any of them fall inside the range of the
site). To run the scrip use the following syntax: `MYSITE=1
./fix.many.id.sh`. The arguments are the same as load.bety.sh in pean.

@mdietze Currently this script will only need to be executed at BU and
should not be run at EBI.