### PR TITLE
modified api search

### DIFF
--- a/lib/simple_search.rb
+++ b/lib/simple_search.rb
@@ -91,8 +91,17 @@ module SimpleSearch
   def api_search(params)
     conditions = {}
     select = []
+    join_model = ''
+    join_table = ''
+    join = params[:join]
     params.each do |k, v|
-      next if !self.column_names.include?(k)
+      if !self.column_names.include?(k)
+        next if !join
+        join_model = join.to_s.classify.constantize
+        join_table = join_model.table_name
+        next if !join_model.column_names.include?(k)
+        k = "#{join_table}.#{k}"
+      end
       conditions[k] = v
     end
     if params["filters"]
@@ -103,7 +112,7 @@ module SimpleSearch
     end
     params[:include] = [] unless params[:include]
     select = ["*"] if select.empty?
-    where(conditions).select(select.join(",")).includes(params[:include])
+    joins(join ? join.to_sym : '').select(select.join(",")).includes(params[:include]).where(conditions)
   end
 
   private


### PR DESCRIPTION
fixes #224 Modified the api_search function to handle explicit table joins. 
<code>https://www.betydb.org/yields.json?genus=Miscanthus</code> this query didn't work because genus is not a field of the yields table, and was discarded at the beginning of the function. With the modified code, this query <code>https://www.betydb.org/yields.json?join=specie&genus=Miscanthus</code> would return all the yield entries with genus Miscanthus along with the species data.
