### PR TITLE
add api_search support to trait and yields view

### DIFF
--- a/app/controllers/traits_and_yields_view_controller.rb
+++ b/app/controllers/traits_and_yields_view_controller.rb
@@ -1,0 +1,15 @@
+class TraitsAndYieldsViewController < ApplicationController
+  before_filter :login_required
+
+  require 'csv'
+
+  def index
+    @data = TraitsAndYieldsView.api_search(params)
+    log_searches(TraitsAndYieldsView.method(:api_search), params)
+    respond_to do |format|
+        format.xml  { render :xml => @data }
+        format.json { render :json => @data }
+        format.csv  { render :csv => @data }
+    end
+  end
+end

--- a/app/models/traits_and_yields_view.rb
+++ b/app/models/traits_and_yields_view.rb
@@ -21,6 +21,8 @@ class TraitsAndYieldsView < ActiveRecord::Base
   extend DataAccess # provides all_limited
 
   extend AdvancedSearch
+
+  extend SimpleSearch
   SEARCH_INCLUDES = %w{ }
   SEARCH_FIELDS = %w{ scientificname commonname trait
                       trait_description city sitename author


### PR DESCRIPTION
Created an index action so traits_and_yields_view can be searched by the api (mainly used by the rOpensci package)