### PR TITLE
Fixed incorrect page title

### DIFF
--- a/app/views/machines/show.html.erb
+++ b/app/views/machines/show.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<div class="sixteen columns">
 			<header>
-				<h1>Viewing PFT</h1>
+				<h1>Viewing Machine</h1>
 			</header>
 			
 			<a style="text-decoration: none" href="#" onclick="showHide('show_files')" id="show_show_files">[+] View Related Files</a>


### PR DESCRIPTION
The machines show page says "Viewing PFT", e.g. https://www.betydb.org/machines/16#

![image](https://cloud.githubusercontent.com/assets/464871/7715706/d59809ea-fe4f-11e4-9018-0c0082577cbc.png)
