### PR TITLE
remove broken 'map' link on site show page

### DIFF
--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -18,10 +18,6 @@
       </table>
 
       <hr>
-
-      <p><span id="site_link_<%= @site.id %>" class="popup_link">Map</span><br />
-        <%#= render :partial => "site_popup", :locals => {:site => @site } %>
-      </p>
       
       
 			<!-- InstanceBeginEditable name="Full Width Content" --> 


### PR DESCRIPTION
closes #305 by removing link that used to provide a popup map