### PR TITLE
Robkooper cluster pecan 629 modified

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -27,7 +27,7 @@ class Cluster < ActiveRecord::Base
   end
 
   def to_s
-    hostname
+    name
   end
 
 end

--- a/app/views/clusters/index.html.erb
+++ b/app/views/clusters/index.html.erb
@@ -5,7 +5,9 @@
 				<h1>Clusters</h1>
 			</header>
       <div id="process_container">
-        <div id="back"><%= link_to 'New Cluster', new_cluster_path, :class => "button button-primary" %></div>
+        <div id="back"><br /></div>
+        <div id="new"><%= link_to 'New Cluster', new_cluster_path, :class => "button button-primary" %></div>
+        <div id="forward"><br /></div>
       </div>
       <br />
       <div id="simple_search_table" class="simple_search_table_1"><%= render 'index_table' %></div>

--- a/db/migrate/20160412030352_add_sites_cluster.rb
+++ b/db/migrate/20160412030352_add_sites_cluster.rb
@@ -1,17 +1,26 @@
 class AddSitesCluster < ActiveRecord::Migration
 
   def up
+    this_hostid = Machine.new.hostid
+
     # The table we want to add:
     create_table :clusters do |t|
       t.string :name, null: false
-      t.boolean :everybody, :default => false
+      t.boolean :everybody, null: false, :default => false
       t.integer :user_id, :limit => 8, null: false
       t.timestamps
     end
     change_column :clusters, :id, :integer, :limit => 8
     # fix the counter for  inserting new records
     execute %{
-        select setval('clusters_id_seq', greatest(1, cast(1e9 * floor(nextval('users_id_seq') / 1e9) as bigint)), false);
+        SELECT setval('clusters_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+        ALTER TABLE clusters
+            ALTER COLUMN created_at SET DEFAULT utc_now(),
+            ALTER COLUMN updated_at SET DEFAULT utc_now(),
+            ADD CONSTRAINT "fk_clusters_users"
+                FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+                ON DELETE RESTRICT
+                ON UPDATE CASCADE;
     }
 
     create_table :clusters_sites do |t|
@@ -20,16 +29,30 @@ class AddSitesCluster < ActiveRecord::Migration
       t.timestamps
     end
     change_column :clusters_sites, :id, :integer, :limit => 8
-    # fix the counter for  inserting new records
+    # fix the counter for inserting new records and add foreign key constraints
     execute %{
-        select setval('clusters_sites_id_seq', greatest(1, cast(1e9 * floor(nextval('users_id_seq') / 1e9) as bigint)), false);        
+        SELECT setval('clusters_sites_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+        ALTER TABLE clusters_sites
+            ALTER COLUMN created_at SET DEFAULT utc_now(),
+            ALTER COLUMN updated_at SET DEFAULT utc_now();
+
+        ALTER TABLE "clusters_sites"
+            ADD CONSTRAINT "fk_clusters_sites_sites"
+                FOREIGN KEY ("site_id") REFERENCES "sites" ("id")
+                ON DELETE CASCADE ON UPDATE CASCADE,
+            ADD CONSTRAINT "fk_clusters_sites_clusters"
+                FOREIGN KEY ("cluster_id") REFERENCES "clusters" ("id")
+                ON DELETE CASCADE ON UPDATE CASCADE;
     }
 
     # only execute if migration is running on host 0
-    if Machine.new.hostid == 0
+    if this_hostid == 0
       execute %{
-        insert into clusters (name, everybody, user_id, created_at, updated_at) values('AmeriFlux', true, 0, now(), now());
-        insert into clusters_sites (cluster_id, site_id, created_at, updated_at) select (select id from clusters where name='AmeriFlux'), id, now(), now() from sites where sitename like '% (US-%)';
+        INSERT INTO clusters (name, everybody, user_id)
+            VALUES('AmeriFlux', true, 0);
+        INSERT INTO clusters_sites (cluster_id, site_id)
+            SELECT (SELECT id FROM clusters WHERE name='AmeriFlux'), id
+                FROM sites WHERE sitename LIKE '% (US-%)';
       }
     end
   end

--- a/lib/authenticated_system.rb
+++ b/lib/authenticated_system.rb
@@ -47,6 +47,7 @@ module AuthenticatedSystem
       # controller_class = controller_class_name if controller_class.nil?
       controller_class = "#{controller_name.camelize}Controller" if controller_class.nil?
       admin_requirement = ["UsersController.ALL",
+#                                "ClustersController.ALL",
                                 "BulkUploadController.ALL" ] # For now, only administrators are allowed access to the insert_data action of the bulk upload wizard.
       manage_requirement = ["BulkUploadController.start_upload", # For now, only administrators and managers are allowed access to the bulk upload wizard.
                                 "BulkUploadController.choose_global_citation",
@@ -100,8 +101,6 @@ module AuthenticatedSystem
                                 "ClustersController.create",
                                 "ClustersController.edit",
                                 "ClustersController.update",
-                                "ClustersSitesController.create",
-                                "ClustersSitesController.new",
                                 "CovariatesController.new",
                                 "CovariatesController.create",
                                 "CovariatesController.edit",
@@ -197,7 +196,6 @@ module AuthenticatedSystem
                                 "ClustersController.index",
                                 "ClustersController.show",
                                 "ClustersController.search",
-                                "ClustersSitesController.index",
                                 "ClustersController.edit_clusters_sites",
                                 "CovariatesController.index",
                                 "CovariatesController.show",

--- a/spec/features/cluster_integration_spec.rb
+++ b/spec/features/cluster_integration_spec.rb
@@ -1,0 +1,163 @@
+require 'support/helpers'
+include LoginHelper
+
+# Override the default path "#{::Rails.root}/spec/fixtures"
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/test/fixtures"
+end
+
+feature 'Authorization:' do
+
+  fixtures :clusters
+
+  let(:private_cluster) { clusters(:private_cluster) }
+
+  let(:public_cluster) { clusters(:public_cluster) }
+
+  context 'Even a Manager' do
+
+    before :each do
+      login_as_manager
+
+      # find the user's name on the home page:
+      current_user_name = first('#header_user_name').text.match(/Logged in as: (.*?) *$/)[1]
+
+      # look up the current user's id:
+      current_user_id = User.find_by_name(current_user_name).id
+
+      # get all of this user's private clusters:
+      @private_clusters_of_this_user = Cluster.where(user_id: current_user_id, everybody: false)
+
+      # get all of this user's public clusters:
+      @public_clusters_of_this_user = Cluster.where(user_id: current_user_id, everybody: true)
+
+      # get all of this user's clusters:
+      @clusters_of_this_user = @private_clusters_of_this_user + @public_clusters_of_this_user
+
+      # get a list of private clusters of other users:
+      @private_clusters_of_other_users = Cluster.where({everybody: false}).where("user_id != ?", current_user_id)
+
+      # get a list of public clusters of other users:
+      @public_clusters_of_other_users = Cluster.where({everybody: true}).where("user_id != ?", current_user_id)
+    end
+
+    specify "shouldn't see private clusters created by other users in the clusters list" do
+      visit '/clusters'
+      @private_clusters_of_other_users.each do |c|
+        expect(page).not_to have_xpath ".//tbody/tr[td/text() = '#{c.name}']"
+      end
+    end
+
+    specify "should see all public clusters and his own private clusters in the clusters list" do
+      visit '/clusters'
+      (@public_clusters_of_other_users + @clusters_of_this_user).each do |c|
+        expect(page).to have_xpath ".//tbody/tr[td/text() = '#{c.name}']"
+      end
+    end
+
+    specify "shouldn't be able to view private clusters of other users" do
+      @private_clusters_of_other_users.each do |c|
+        visit "/clusters/#{c.id}"
+        expect(page).not_to have_content 'Viewing Cluster'
+      end
+    end
+
+    specify "should be able to view private clusters of his own" do
+      @private_clusters_of_this_user.each do |c|
+        visit "/clusters/#{c.id}"
+        expect(page).to have_content 'Viewing Cluster'
+      end
+    end
+
+    specify "shouldn't see an edit button for a public cluster created by another user" do
+      visit '/clusters'
+      expect(page).not_to have_xpath('.//tr[td/text() = "public_cluster"][td/a[contains(@href, "/edit")]]')
+    end
+
+    # Ensure the previous test wasn't a false negative:
+    specify "should see an edit button for a public cluster created by himself" do
+      visit '/clusters'
+      expect(page).to have_xpath('.//tr[td/text() = "creator_public_cluster"][td/a[contains(@href, "/edit")]]')
+    end
+
+    specify "shouldn't see a delete button for a public cluster created by another user" do
+      visit '/clusters'
+      expect(page).not_to have_xpath('.//tr[td/text() = "public_cluster"][td/a[@data-method = "delete"]]')
+    end
+
+    specify "shouldn't see an delete button even for a public cluster created by himself" do
+      visit '/clusters'
+      expect(page).not_to have_xpath('.//tr[td/text() = "creator_public_cluster"][td/a[@data-method = "delete"]]')
+    end
+
+    specify "shouldn't have edit access to even a public cluster created by another user" do
+      visit "/clusters/#{public_cluster.id}/edit"
+      expect(page).not_to have_content 'Editing Cluster'
+    end
+
+    specify "shouldn't have delete permission for a cluster created by another user", type: :routing do
+      expect { delete("/clusters/#{private_cluster.id}") }.to change { Cluster.count }.by 0
+    end
+
+  end
+
+  context 'An Administrator' do
+
+    before :each do
+      login_test_user
+    end
+
+    specify "should see a clusters list containing all clusters" do
+      visit '/clusters'
+      expect(all(:xpath, ".//tbody/tr").length).to eq Cluster.count
+    end
+
+    specify "should see edit buttons for all items in the clusters list" do
+      visit '/clusters'
+      expect(all(:xpath, ".//tbody/tr[td/a[contains(@href, '/edit')]]").length).to eq Cluster.count
+    end
+
+    specify "should see delete buttons for all items in the clusters list" do
+      visit '/clusters'
+      expect(all(:xpath, ".//tbody/tr[td/a[@data-method = 'delete']]").length).to eq Cluster.count
+    end
+
+    specify "should be able to view private clusters created by other users" do
+      cluster = clusters(:private_cluster_from_creator_user)
+      id = cluster.id
+      visit "/clusters/#{id}"
+      expect(page).to have_content "Viewing Cluster"
+      expect(page).to have_content cluster.name
+    end
+
+    specify "should have edit access to private clusters created by other users" do
+      cluster = clusters(:private_cluster_from_creator_user)
+      id = cluster.id
+      visit "/clusters/#{id}/edit"
+      expect(page).to have_content "Editing Cluster"
+    end
+
+    specify "should be able to edit private clusters created by other users" do
+      cluster = clusters(:private_cluster_from_creator_user)
+      id = cluster.id
+      visit "/clusters/#{id}/edit"
+      fill_in 'Name', with: 'my new name'
+      click_button 'Update'
+      expect(Cluster.find_all_by_name('my new name').count).to eq 1
+    end
+
+    specify "should be able to delete private clusters created by other users" do
+      visit "/clusters"
+      expect do
+        first(:xpath, ".//tbody/tr[td/text() = 'creator_private_cluster']/td/a[@data-method = 'delete']").click
+      end.to change { Cluster.count }.by(-1)
+    end
+
+
+  end
+
+
+end
+
+
+      

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -21,6 +21,10 @@ module LoginHelper
     fill_in 'Password', :with => 'fizzie'
     click_button 'Log in'
   end
+
+  alias_method :login_as_adminstrator, :login_test_user
+  alias_method :login_as_manager, :login_nonadmin_test_user
+
 end
 
 module BulkUploadHelper

--- a/test/fixtures/clusters.yml
+++ b/test/fixtures/clusters.yml
@@ -1,0 +1,24 @@
+private_cluster:
+  id: 1
+  name: private_cluster
+  everybody: f
+  user_id: 1
+
+public_cluster:
+  id: 2
+  name: public_cluster
+  everybody: t
+  user_id: 1
+
+public_cluster_from_creator_user:
+  id: 3
+  name: creator_public_cluster
+  everybody: t
+  user_id: 2
+
+private_cluster_from_creator_user:
+  id: 4
+  name: creator_private_cluster
+  everybody: f
+  user_id: 2
+

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,6 +8,7 @@
 test_user1:
     id: 1
     login: 'carlcrott'
+    name: 'Carl Crott'
     #crypted_password: 'ace7e0ca3ca773bc2ce6ae77c445955283fb3810' # This hard-coded value only works if REST_AUTH_SITE_KEY = 'thisisnotasecret'
     # Replacing the hard-coded crypted_password above with the computed crypted_password below makes the test login work with any value of REST_AUTH_SITE_KEY
     crypted_password: <%= User.password_digest(test_user1_password, salt) %>
@@ -18,6 +19,7 @@ test_user1:
 
 test_user2:
     login: 'test_admin_user'
+    name: 'An Administrator'
     #crypted_password: '1fd4c5fd881ac316702ebcba084b7e89f154de56' # This hard-coded value only works if REST_AUTH_SITE_KEY = 'thisisnotasecret'
     # Replacing the hard-coded crypted_password above with the computed crypted_password below makes the test login work with any value of REST_AUTH_SITE_KEY
     crypted_password: <%= User.password_digest(test_user2_password, salt) %>
@@ -30,6 +32,7 @@ test_user2:
 test_user3:
     id: 2
     login: 'robben_yang'
+    name: 'Robben Yang'
     #crypted_password: 'ddbf27adfbcb94037a6f1b9b1f762ff601058b8d' # This hard-coded value only works if REST_AUTH_SITE_KEY = 'thisisnotasecret'
     # Replacing the hard-coded crypted_password above with the computed crypted_password below makes the test login work with any value of REST_AUTH_SITE_KEY
     crypted_password: <%= User.password_digest(test_user3_password, salt) %>
@@ -40,6 +43,7 @@ test_user3:
 test_user4:
     id: 3
     login: 'test_user'
+    name: 'Another Administrator'
     #crypted_password: '1fd4c5fd881ac316702ebcba084b7e89f154de56' # This hard-coded value only works if REST_AUTH_SITE_KEY = 'thisisnotasecret'
     # Replacing the hard-coded crypted_password above with the computed crypted_password below makes the test login work with any value of REST_AUTH_SITE_KEY
     crypted_password: <%= User.password_digest(test_user2_password, salt) %>
@@ -50,6 +54,7 @@ test_user4:
 public_creator:
     id: 4
     login: 'creator'
+    name: 'A Creator'
     #crypted_password: '572f8c2e779cb678b517fec32130d30953b363f5' # This hard-coded value only works if REST_AUTH_SITE_KEY = 'thisisnotasecret'
     # Replacing the hard-coded crypted_password above with the computed crypted_password below makes the test login work with any value of REST_AUTH_SITE_KEY
     crypted_password: <%= User.password_digest(public_creator_password, salt) %>


### PR DESCRIPTION
Comments on pull request

* `Cluster#to_s` returned `hostname`, which throws a method missing error.  I made it return `name`.
* I made several changes to the migration.
 * I added three foreign-key constraints.
 * I made "everybody" non null.
 * I gave all timestamp column a default of utc_now() and these defaults are now used by the insert statements.
* Changes to the AuthenticatedSystem module:
 * I removed references to ClustersSitesController.  These controllers don't exist and so this list items have no effect.
 * I added "ClustersController.ALL" to the admin_requirement list.  This isn't really necessary since you added the fallback to level 1 if the controller action is not found in any list, but I think the fallback option shouldn't be used except as a stopgap to programming neglect.
 * I modified the Clusters index view template so that the "New Cluster" buttons is centered to be consistent with other pages.
 * I added some RSpec tests having to do with authorization to do various things with clusters.


Questions

* Are you really wanting to start the sequences at (1e9 * n) and not (1e9 * n) + 1?
* I assume that you have reasons unrelated to clusters for adding methods #hostid, #host_start, and #host_end to Machines.  But since we have #hostid, I used it in the migration in the two setval calls to avoid repeating code.  But if there's some reason not to, change it back.