### PR TITLE
Correct Data Entry link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ BETYdb provides an interface for contributing and accessing data, and is the inf
 ## Documentation.
 
 * Technical Documentation: https://pecan.gitbooks.io/betydb-documentation/content/
-* Data Entry: https://www.gitbook.com/book/pecan/betydbdoc-dataentry/content/
-* Data Access: https://www.gitbook.com/book/pecan/betydb-data-access/content/
+* Data Entry: https://www.gitbook.com/book/pecan/betydbdoc-dataentry/details
+* Data Access: https://www.gitbook.com/book/pecan/betydb-data-access/details
  


### PR DESCRIPTION
The Data Entry (https://www.gitbook.com/book/pecan/betydbdoc-dataentry/content/) and Data Access (https://www.gitbook.com/book/pecan/betydb-data-access/content/) links don't appear to be working. I did some digging and replaced them with working links to (I hope!) the correct content.

Great resource by the way!