### PR TITLE
Customization

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,6 +144,10 @@ def commit_tags
   ref_array.join(', ')
 end
 
+def commit_branch
+  `git rev-parse --abbrev-ref HEAD`
+end
+
 def commit_checksum
   `git log --pretty=format:"%H" -1`
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,3 +123,31 @@ def autocompletion_field(f, label, table_name, id, placeholder, display_value = 
                           class: autocompletion_class)).
     concat(f.hidden_field id)
 end
+
+def commit_is_tagged?
+  !commit_tags.blank?
+end
+
+def commit_tags
+  ref_names = `git log --pretty=format:"%d" -1`
+  if /tag/.match(ref_names).nil?
+    return ""
+  end
+
+  # If we required a version of Git recent enough to support the %D placeholder,
+  # we wouldn't need the following line:
+  ref_names.sub!(/ *\(([^)]*)\) */, '\1')
+
+  ref_array = ref_names.split(',')
+  ref_array.keep_if { |ref| /tag/.match(ref) }
+  ref_array.collect! { |ref| ref.sub(/tag: *(.*) */, '\1') }
+  ref_array.join(', ')
+end
+
+def commit_checksum
+  `git log --pretty=format:"%H" -1`
+end
+
+def commit_date
+  `git log --pretty=format:"%ad" -1`
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -115,12 +115,12 @@
     <div class="container">
       <div class="sixteen columns">
         <h1 class="remove-bottom">
-          <a href="<%= CONFIG[:organization_url] %>"
+          <a href="<%= CONFIG.try(:[], :organization).try(:[], :url) %>"
              class="org"
              style="background: url(/images/<%=
-                    CONFIG[:organization_logo_file_name]
+                    CONFIG.try(:[], :organization).try(:[], :logo_file_name)
                     %>) top right no-repeat">
-            <%= CONFIG[:organization_name] %>
+            <%= CONFIG.try(:[], :organization).try(:[], :name) %>
           </a>
           <a href="/" class="site">
             <%= raw(CONFIG[:site_identification_markup]) %>
@@ -287,7 +287,7 @@
       <hr />
       <div class="row">
         <div class="footnotes">
-        <% sponsers = CONFIG[:sponsers]
+        <% (sponsers = CONFIG[:sponsers]) &&
           sponsers.each_with_index do |sponser, i| %>
           <div class="four columns
                       <%= if i == 0
@@ -296,7 +296,7 @@
                             "omega"
                           end %>">
             <a href="<%= sponser[:URL] %>" title="<%= sponser[:title] %>"
-               style="background: url(../images/<%=
+               style="background: url(images/<%=
                                         sponser[:logo_file]
                                       %>) 0 0 no-repeat;
                       width: <%= sponser[:width] %>;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -115,12 +115,12 @@
     <div class="container">
       <div class="sixteen columns">
         <h1 class="remove-bottom">
-          <a href="<%= CONFIG.try(:[], :organization).try(:[], :url) %>"
+          <a href="<%= CONFIG[:organization].try(:[], :url) %>"
              class="org"
-             style="background: url(/images/<%=
-                    CONFIG.try(:[], :organization).try(:[], :logo_file_name)
-                    %>) top right no-repeat">
-            <%= CONFIG.try(:[], :organization).try(:[], :name) %>
+             style="background: url(<%= image_path(
+                    CONFIG[:organization].try(:[], :logo_file_name)
+                    ) %>) top right no-repeat">
+            <%= CONFIG[:organization].try(:[], :name) %>
           </a>
           <a href="/" class="site">
             <%= raw(CONFIG[:site_identification_markup]) %>
@@ -282,7 +282,7 @@
             <li><a href="https://gitter.im/PecanProject/bety?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Chat Room"></a></li>
           </ul>
         </div>
-        <div class="six columns omega" style="background: url(/images/<%= CONFIG[:footer_background_image_file_name] %>) top center no-repeat">
+        <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file_name]) %>) top center no-repeat">
           <%= raw(CONFIG[:citation_license_copyright_markup]) %>
         </div>
       </div>
@@ -298,9 +298,9 @@
                             "omega"
                           end %>">
             <a href="<%= sponsor[:URL] %>" title="<%= sponsor[:title] %>"
-               style="background: url(images/<%=
+               style="background: url(<%= image_path(
                                         sponsor[:logo_file]
-                                      %>) 0 0 no-repeat;
+                                      ) %>) 0 0 no-repeat;
                       width: <%= sponsor[:width] %>;
                       <%= sponsor[:additional_styling] %>">
               <%= sponsor[:text] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -285,15 +285,17 @@
         <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file]) %>) top center no-repeat">
           <%= raw(CONFIG[:citation_license_copyright_markup]) %>
           <div class="version_info">
-            <h3>Version Information</h3>
+            <h3>Powered by <a href="https://github.com/PecanProject/bety">BETYdb</a></h3>
             <p>
               <% if commit_is_tagged? %>
               <span class="identifier">Tag:</span> <%= commit_tags %>
               <br />
               <% end %>
+              <span class="identifier">Branch:</span> <%= commit_branch %>
+              <br />
               <span class="identifier">Date:</span> <%= commit_date %>
               <br />
-              <span class="identifier">Checksum:</span> <%= commit_checksum %>
+              <span class="identifier">Checksum:</span> <%= commit_checksum[0..6] %>
             </p>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -289,21 +289,21 @@
       <hr />
       <div class="row">
         <div class="footnotes">
-        <% (sponsers = CONFIG[:sponsers]) &&
-          sponsers.each_with_index do |sponser, i| %>
+        <% (sponsors = CONFIG[:sponsors]) &&
+          sponsors.each_with_index do |sponsor, i| %>
           <div class="four columns
                       <%= if i == 0
                             "alpha"
-                          elsif i == sponsers.size - 1
+                          elsif i == sponsors.size - 1
                             "omega"
                           end %>">
-            <a href="<%= sponser[:URL] %>" title="<%= sponser[:title] %>"
+            <a href="<%= sponsor[:URL] %>" title="<%= sponsor[:title] %>"
                style="background: url(images/<%=
-                                        sponser[:logo_file]
+                                        sponsor[:logo_file]
                                       %>) 0 0 no-repeat;
-                      width: <%= sponser[:width] %>;
-                      <%= sponser[:additional_styling] %>">
-              <%= sponser[:text] %>
+                      width: <%= sponsor[:width] %>;
+                      <%= sponsor[:additional_styling] %>">
+              <%= sponsor[:text] %>
             </a>
           </div>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -284,20 +284,6 @@
         </div>
         <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file]) %>) top center no-repeat">
           <%= raw(CONFIG[:citation_license_copyright_markup]) %>
-          <div class="version_info">
-            <h3>Powered by <a href="https://github.com/PecanProject/bety">BETYdb</a></h3>
-            <p>
-              <% if commit_is_tagged? %>
-              <span class="identifier">Tag:</span> <%= commit_tags %>
-              <br />
-              <% end %>
-              <span class="identifier">Branch:</span> <%= commit_branch %>
-              <br />
-              <span class="identifier">Date:</span> <%= commit_date %>
-              <br />
-              <span class="identifier">Checksum:</span> <%= commit_checksum[0..6] %>
-            </p>
-          </div>
         </div>
       </div>
       <hr />
@@ -321,6 +307,21 @@
             </a>
           </div>
         <% end %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="git_info">
+          <h3>Powered by <a href="https://github.com/PecanProject/bety">BETYdb</a></h3>
+          <div class="version_info">
+          <% if commit_is_tagged? %>
+          (<div class="first"><span class="identifier">Tag:</span><span class="value"><%= commit_tags %></span></div>
+          <div><span class="identifier">Branch:</span><span class="value"><%= commit_branch %></span></div>
+          <% else %>
+          (<div class="first"><span class="identifier">Branch:</span><span class="value"><%= commit_branch %></span></div>
+          <% end %>
+          <div><span class="identifier">Date:</span><span class="value"><%= commit_date %></span></div>
+          <div class="last"><span class="identifier">Checksum:</span><span class="value"><%= commit_checksum[0..6] %></span></div>)
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -284,6 +284,18 @@
         </div>
         <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file]) %>) top center no-repeat">
           <%= raw(CONFIG[:citation_license_copyright_markup]) %>
+          <div class="version_info">
+            <h3>Version Information</h3>
+            <p>
+              <% if commit_is_tagged? %>
+              <span class="identifier">Tag:</span> <%= commit_tags %>
+              <br />
+              <% end %>
+              <span class="identifier">Date:</span> <%= commit_date %>
+              <br />
+              <span class="identifier">Checksum:</span> <%= commit_checksum %>
+            </p>
+          </div>
         </div>
       </div>
       <hr />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -114,7 +114,18 @@
   <div class="header">
     <div class="container">
       <div class="sixteen columns">
-        <h1 class="remove-bottom"><a href="/" class="org">Energy Biosciences Institute</a> <a href="/" class="site"><strong>BETY</strong>db <small><strong>Biofuel Ecophysiological Traits and Yields </strong>Database</small></a></h1>
+        <h1 class="remove-bottom">
+          <a href="<%= CONFIG[:organization_url] %>"
+             class="org"
+             style="background: url(/images/<%=
+                    CONFIG[:organization_logo_file_name]
+                    %>) top right no-repeat">
+            <%= CONFIG[:organization_name] %>
+          </a>
+          <a href="/" class="site">
+            <%= raw(CONFIG[:site_identification_markup]) %>
+          </a>
+        </h1>
         <div id="header_user_name">
           <% if current_user != nil %>
             Logged in as: <%= current_user %>
@@ -269,25 +280,31 @@
             <li><a href="https://gitter.im/PecanProject/bety?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Chat Room"></a></li>
           </ul>
         </div>
-        <div class="six columns omega">
-          <p>LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney, Gareth Scott Rohde, Dan Wang (2010).
-                     <cite>Biofuel Ecophysiological Traits and Yields Database (BETYdb)</cite>,
-                     Energy Biosciences Institute, University of Illinois at Urbana-Champaign.
-                     doi:10.13012/J8H41PB9</p>
-                  <p>All public data in BETYdb is made available under the
-                     <a href="http://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) v1.0.</a>
-                     You are free to share, create, and adapt its contents.
-                     Data with an access_level field and value &lt;= 2 is not covered by this license but may be available for use with consent.</p>
-          <p>Copyright © 2010-2014 Energy Biosciences Institute</p>
+        <div class="six columns omega" style="background: url(/images/<%= CONFIG[:footer_background_image_file_name] %>) top center no-repeat">
+          <%= raw(CONFIG[:citation_license_copyright_markup]) %>
         </div>
       </div>
       <hr />
       <div class="row">
         <div class="footnotes">
-          <div class="four columns alpha"><a href="http://illinois.edu" title="University of Illinois at Urbana-Champaign" class="illinois">University of Illinois at Urbana-Champaign</a></div>
-          <div class="four columns"><a href="http://www.berkeley.edu" title="University of California, Berkeley" class="berkeley">University of California, Berkeley</a></div>
-          <div class="four columns"><a href="http://www.lbl.gov" title="Lawrence Berkeley National Laboratory (LBL)" class="lbl">Lawrence Berkeley National Laboratory</a></div>
-          <div class="four columns omega"><a href="http://www.bp.com" title="British Petroleum (BP)" class="bp">British Petroleum (BP)</a></div>
+        <% sponsers = CONFIG[:sponsers]
+          sponsers.each_with_index do |sponser, i| %>
+          <div class="four columns
+                      <%= if i == 0
+                            "alpha"
+                          elsif i == sponsers.size - 1
+                            "omega"
+                          end %>">
+            <a href="<%= sponser[:URL] %>" title="<%= sponser[:title] %>"
+               style="background: url(../images/<%=
+                                        sponser[:logo_file]
+                                      %>) 0 0 no-repeat;
+                      width: <%= sponser[:width] %>;
+                      <%= sponser[:additional_styling] %>">
+              <%= sponser[:text] %>
+            </a>
+          </div>
+        <% end %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -268,7 +268,9 @@
           <ul class="unstyled">
                       <li><%= link_to "Homepage", root_path %></li>
                       <li><%= link_to "Documentation", "https://pecan.gitbooks.io/betydb-documentation/content/", :target =>"_blank" %></li>
+                      <% if CONFIG[:show_crop_map_links] %>
                       <li><%= link_to "Maps & Data", maps_path %></li>
+                      <% end %>
           </ul>
         </div>
         <div class="three columns">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -118,7 +118,7 @@
           <a href="<%= CONFIG[:organization].try(:[], :url) %>"
              class="org"
              style="background: url(<%= image_path(
-                    CONFIG[:organization].try(:[], :logo_file_name)
+                    CONFIG[:organization].try(:[], :logo_file)
                     ) %>) top right no-repeat">
             <%= CONFIG[:organization].try(:[], :name) %>
           </a>
@@ -282,7 +282,7 @@
             <li><a href="https://gitter.im/PecanProject/bety?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Chat Room"></a></li>
           </ul>
         </div>
-        <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file_name]) %>) top center no-repeat">
+        <div class="six columns omega" style="background: url(<%= image_path(CONFIG[:footer_background_image_file]) %>) top center no-repeat">
           <%= raw(CONFIG[:citation_license_copyright_markup]) %>
         </div>
       </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,11 +7,11 @@
       <!-- InstanceBeginEditable name="Full Width Content" -->
       <div class="row">
       <div class="ten columns alpha">
-	<p class="lead"><%= CONFIG.try(:[], :homepage_body).try(:[], :lead_text) %></p>
+	<p class="lead"><%= CONFIG[:homepage_body].try(:[], :lead_text) %></p>
 	
-	<div class="inline-block" style="width: 400px"><%= raw CONFIG.try(:[], :homepage_body).try(:[], :marked_up_block_text) %></div>
+	<div class="inline-block" style="width: 400px"><%= raw CONFIG[:homepage_body].try(:[], :marked_up_block_text) %></div>
 	<div class="inline-block" style="width: 160px; vertical-align:top; margin-left:10px">
-          <%= image_tag CONFIG.try(:[], :homepage_body).try(:[], :photo).try(:[], :file_name), class: "inline-block", alt: CONFIG.try(:[], :homepage_body).try(:[], :photo).try(:[], :alt_text) %>
+          <%= image_tag CONFIG[:homepage_body].try(:[], :photo).try(:[], :file_name), class: "inline-block", alt: CONFIG[:homepage_body].try(:[], :photo).try(:[], :alt_text) %>
 	</div>
 	
 	<% if current_user.nil? %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,16 +2,16 @@
   <div class="container">
     <div class="sixteen columns">
       <header>
-	<h1>Welcome to BETYdb</h1>
+	<h1><%= CONFIG[:homepage_heading] %></h1>
       </header>
       <!-- InstanceBeginEditable name="Full Width Content" -->
       <div class="row">
       <div class="ten columns alpha">
-	<p class="lead">The emerging biofuel industry may aid in reducing greenhouse gas emissions and decreasing dependence on foreign oil importation.</p>
+	<p class="lead"><%= CONFIG[:homepage_lead_text] %></p>
 	
-	<div class="inline-block" style="width: 400px">How to develop and implement biofuel crops in an ecologically and economically sustainable way requires evaluating the growth and functionality of biofuel crops from the local scale to the regional scale. <strong class="green">BETYdb</strong> has been developed to support research, agriculture, and policy by synthesizing available information on potential biofuel crops.</div>
+	<div class="inline-block" style="width: 400px"><%= raw CONFIG[:homepage_markedup_block_text] %></div>
 	<div class="inline-block" style="width: 160px; vertical-align:top; margin-left:10px">
-          <%= image_tag 'miscanthus.jpg', class: "inline-block", alt: "Photo by L. Brian Stauffer, provided by University of Illinois at Urbana-Champaign" %>
+          <%= image_tag CONFIG[:homepage_photo_file], class: "inline-block", alt: CONFIG[:homepage_photo_alt_text] %>
 	</div>
 	
 	<% if current_user.nil? %>
@@ -68,6 +68,7 @@
 	  </div>
           <% end %>
 	</div>
+    <% if CONFIG[:show_crop_map_link] %>
 	<div>
 	  <h3><i class="icon-eye-open"></i> COMPARE <em> CROP FORECASTS </em></h3>
 	  <div class="sidebar">
@@ -80,7 +81,8 @@
 	    </ul>
 	  </div>
 	</div>
-      </div>
+    <% end %>
+  </div>
 </div>
 
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,11 +7,11 @@
       <!-- InstanceBeginEditable name="Full Width Content" -->
       <div class="row">
       <div class="ten columns alpha">
-	<p class="lead"><%= CONFIG[:homepage_lead_text] %></p>
+	<p class="lead"><%= CONFIG.try(:[], :homepage_body).try(:[], :lead_text) %></p>
 	
-	<div class="inline-block" style="width: 400px"><%= raw CONFIG[:homepage_markedup_block_text] %></div>
+	<div class="inline-block" style="width: 400px"><%= raw CONFIG.try(:[], :homepage_body).try(:[], :marked_up_block_text) %></div>
 	<div class="inline-block" style="width: 160px; vertical-align:top; margin-left:10px">
-          <%= image_tag CONFIG[:homepage_photo_file], class: "inline-block", alt: CONFIG[:homepage_photo_alt_text] %>
+          <%= image_tag CONFIG.try(:[], :homepage_body).try(:[], :photo).try(:[], :file_name), class: "inline-block", alt: CONFIG.try(:[], :homepage_body).try(:[], :photo).try(:[], :alt_text) %>
 	</div>
 	
 	<% if current_user.nil? %>
@@ -68,7 +68,7 @@
 	  </div>
           <% end %>
 	</div>
-    <% if CONFIG[:show_crop_map_link] %>
+    <% if CONFIG.try(:[], :homepage_body).try(:[], :show_crop_map_link) %>
 	<div>
 	  <h3><i class="icon-eye-open"></i> COMPARE <em> CROP FORECASTS </em></h3>
 	  <div class="sidebar">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,7 +11,7 @@
 	
 	<div class="inline-block" style="width: 400px"><%= raw CONFIG[:homepage_body].try(:[], :marked_up_block_text) %></div>
 	<div class="inline-block" style="width: 160px; vertical-align:top; margin-left:10px">
-          <%= image_tag CONFIG[:homepage_body].try(:[], :photo).try(:[], :file_name), class: "inline-block", alt: CONFIG[:homepage_body].try(:[], :photo).try(:[], :alt_text) %>
+          <%= image_tag CONFIG[:homepage_body].try(:[], :photo).try(:[], :file), class: "inline-block", alt: CONFIG[:homepage_body].try(:[], :photo).try(:[], :alt_text) %>
 	</div>
 	
 	<% if current_user.nil? %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -68,7 +68,7 @@
 	  </div>
           <% end %>
 	</div>
-    <% if CONFIG.try(:[], :homepage_body).try(:[], :show_crop_map_link) %>
+    <% if CONFIG[:show_crop_map_links] %>
 	<div>
 	  <h3><i class="icon-eye-open"></i> COMPARE <em> CROP FORECASTS </em></h3>
 	  <div class="sidebar">

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -3,10 +3,10 @@
 # should always override these defaults to provide meaningful values!
 
 
-
-organization_name: "Energy Biosciences Institute"
-organization_url: "/"
-organization_logo_file_name: "logo-ebi.png"
+organization:
+  name: "Energy Biosciences Institute"
+  url: "/"
+  logo_file_name: "logo-ebi.png"
 
 site_identification_markup: "<strong>BETY</strong>db <small><strong>Biofuel Ecophysiological Traits and Yields </strong>Database</small>"
 
@@ -62,28 +62,32 @@ sponsers:
 
 homepage_heading: "Welcome to BETYdb"
 
-homepage_lead_text:
+homepage_body:
 
-  The emerging biofuel industry may aid in reducing greenhouse gas emissions and
-  decreasing dependence on foreign oil importation."
+  lead_text:
 
-homepage_markedup_block_text:
+    The emerging biofuel industry may aid in reducing greenhouse gas emissions and
+    decreasing dependence on foreign oil importation."
 
-  How to develop and implement biofuel crops in an ecologically and economically
-  sustainable way requires evaluating the growth and functionality of biofuel
-  crops from the local scale to the regional scale. <strong
-  class="green">BETYdb</strong> has been developed to support research,
-  agriculture, and policy by synthesizing available information on potential
-  biofuel crops.
+  marked_up_block_text:
 
-homepage_photo_file: miscanthus.jpg
+    How to develop and implement biofuel crops in an ecologically and economically
+    sustainable way requires evaluating the growth and functionality of biofuel
+    crops from the local scale to the regional scale. <strong
+    class="green">BETYdb</strong> has been developed to support research,
+    agriculture, and policy by synthesizing available information on potential
+    biofuel crops.
 
-homepage_photo_alt_text:
+  photo:
 
-  Photo by L. Brian Stauffer, provided by University of Illinois at
-  Urbana-Champaign
+    file_name: miscanthus.jpg
 
-show_crop_map_link: true
+    alt_text:
+
+      Photo by L. Brian Stauffer, provided by University of Illinois at
+      Urbana-Champaign
+
+  show_crop_map_link: true
 
 # Override this with a secret key to run a secure site:
 rest_auth_site_key: 'thisisnotasecret'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -87,7 +87,10 @@ homepage_body:
       Photo by L. Brian Stauffer, provided by University of Illinois at
       Urbana-Champaign
 
-  show_crop_map_link: true
+# Miscellaneous
+
+## This affects both the home page and the footer:
+show_crop_map_links: true
 
 # Override this with a secret key to run a secure site:
 rest_auth_site_key: 'thisisnotasecret'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -34,7 +34,7 @@ citation_license_copyright_markup:
 
   <p>Copyright © 2010-2014 Energy Biosciences Institute</p>
 
-sponsers:
+sponsors:
     - URL: http://illinois.edu
       title: "University of Illinois at Urbana-Champaign"
       text: "University of Illinois at Urbana-Champaign"
@@ -67,7 +67,7 @@ homepage_body:
   lead_text:
 
     The emerging biofuel industry may aid in reducing greenhouse gas emissions and
-    decreasing dependence on foreign oil importation."
+    decreasing dependence on foreign oil importation.
 
   marked_up_block_text:
 

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -2,9 +2,88 @@
 # if you don't make an application.yml configuration file.  But a real site
 # should always override these defaults to provide meaningful values!
 
-# Contact Information
+
+
+organization_name: "Energy Biosciences Institute"
+organization_url: "/"
+organization_logo_file_name: "logo-ebi.png"
+
+site_identification_markup: "<strong>BETY</strong>db <small><strong>Biofuel Ecophysiological Traits and Yields </strong>Database</small>"
+
+
+# Footer
+
+footer_background_image_file_name: "logo-ebi-footer.jpg"
+
+## Contact Information
 admin_phone: "(000) 000-0000"
 admin_email: "admin@example.com" # a test
+
+citation_license_copyright_markup:
+
+  <p>LeBauer, David, Michael Dietze, Rob Kooper, Steven Long, Patrick Mulrooney,
+  Gareth Scott Rohde, Dan Wang (2010).  <cite>Biofuel Ecophysiological Traits
+  and Yields Database (BETYdb)</cite>, Energy Biosciences Institute, University
+  of Illinois at Urbana-Champaign.  doi:10.13012/J8H41PB9</p>
+
+  <p>All public data in BETYdb is made available under the <a
+  href="http://opendatacommons.org/licenses/by/1-0/">Open Data Commons
+  Attribution License (ODC-By) v1.0.</a> You are free to share, create, and
+  adapt its contents.  Data with an access_level field and value &lt;= 2 is not
+  covered by this license but may be available for use with consent.</p>
+
+  <p>Copyright © 2010-2014 Energy Biosciences Institute</p>
+
+sponsers:
+    - URL: http://illinois.edu
+      title: "University of Illinois at Urbana-Champaign"
+      text: "University of Illinois at Urbana-Champaign"
+      logo_file: logo-illinois.png
+      width: 246px
+    - URL: http://www.berkeley.edu
+      title: "University of California, Berkeley"
+      text: "University of California, Berkeley"
+      logo_file: logo-berkeley.png
+      width: 145px
+      additional_styling: "margin-left: 20%"
+    - URL: http://www.lbl.gov
+      title: "Lawrence Berkeley National Laboratory (LBL)"
+      text: "Lawrence Berkeley National Laboratory"
+      logo_file: logo-lbl.png
+      width: 232px
+    - URL: http://www.bp.com
+      title: "British Petroleum (BP)"
+      text: "British Petroleum (BP)"
+      logo_file: logo-bp.png
+      width: 54px
+      additional_styling: "margin-right: 40%"
+
+# Home Page
+
+homepage_heading: "Welcome to BETYdb"
+
+homepage_lead_text:
+
+  The emerging biofuel industry may aid in reducing greenhouse gas emissions and
+  decreasing dependence on foreign oil importation."
+
+homepage_markedup_block_text:
+
+  How to develop and implement biofuel crops in an ecologically and economically
+  sustainable way requires evaluating the growth and functionality of biofuel
+  crops from the local scale to the regional scale. <strong
+  class="green">BETYdb</strong> has been developed to support research,
+  agriculture, and policy by synthesizing available information on potential
+  biofuel crops.
+
+homepage_photo_file: miscanthus.jpg
+
+homepage_photo_alt_text:
+
+  Photo by L. Brian Stauffer, provided by University of Illinois at
+  Urbana-Champaign
+
+show_crop_map_link: true
 
 # Override this with a secret key to run a secure site:
 rest_auth_site_key: 'thisisnotasecret'

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -6,14 +6,14 @@
 organization:
   name: "Energy Biosciences Institute"
   url: "/"
-  logo_file_name: "logo-ebi.png"
+  logo_file: "logo-ebi.png"
 
 site_identification_markup: "<strong>BETY</strong>db <small><strong>Biofuel Ecophysiological Traits and Yields </strong>Database</small>"
 
 
 # Footer
 
-footer_background_image_file_name: "logo-ebi-footer.jpg"
+footer_background_image_file: "logo-ebi-footer.jpg"
 
 ## Contact Information
 admin_phone: "(000) 000-0000"
@@ -80,7 +80,7 @@ homepage_body:
 
   photo:
 
-    file_name: miscanthus.jpg
+    file: miscanthus.jpg
 
     alt_text:
 

--- a/public/stylesheets/layout.css
+++ b/public/stylesheets/layout.css
@@ -484,6 +484,13 @@ border-bottom-color: transparent;
 	border-bottom-color: #efefef;
 }
 
+.footer .version_info h3 {
+    margin-bottom: 2px;
+}
+
+.footer .version_info .identifier {
+    font-weight: bold;
+}
 
 
 /* #Media Queries

--- a/public/stylesheets/layout.css
+++ b/public/stylesheets/layout.css
@@ -484,12 +484,45 @@ border-bottom-color: transparent;
 	border-bottom-color: #efefef;
 }
 
-.footer .version_info h3 {
-    margin-bottom: 2px;
+
+/* BETYdb Git information */
+
+.footer .git_info {
+    margin-left: 80px;
 }
 
-.footer .version_info .identifier {
-    font-weight: bold;
+.footer .git_info h3 {
+    margin: 0 10px 0 0;
+    float: left;
+    position: relative;
+    top: 1px;
+}
+
+.footer .git_info .version_info {
+    margin: 0 8px;
+    float: left;
+}
+
+.footer .git_info .version_info > div {
+    display: inline-block;
+    margin: 0 6px;
+}
+
+.footer .git_info .version_info > div.first {
+    margin-left: 0;
+}
+
+.footer .git_info .version_info > div.last {
+    margin-right: 0;
+}
+
+.footer .git_info .identifier {
+    font-variant: small-caps;
+}
+
+.footer .git_info .value {
+    margin-left: 0.3em;
+    font-size: smaller;
 }
 
 


### PR DESCRIPTION
Here's a draft of an extension of the customization mechanism to most of the elements of interest on the Home page.  I suggest checking out this branch and trying out some of the features, either by creating or changing your `config/application.yml` file or temporarily tweaking the checked-in `config/defaults.yml` file.  I've deployed this branch to pecandev/beta; feel free to tweak that code also.  You will have to restart the Rails server (`touch tmp/restart.txt`) after each change you make in order for the results to be visible.  (If you are just running your own copy under the WEBrick Rails server, you just have to CTRL-C and reissue the command `rails server` or `rails s`.)

# Notes

I’ve implemented customization of almost all the outlined regions in the diagram shown in issue https://github.com/PecanProject/bety/issues/368.

![image](https://cloud.githubusercontent.com/assets/464871/11227002/0cfd6e42-8d49-11e5-8285-028966e16b9d.png)

Here are the keys for each item in the diagram, shown in left-to-right order starting at the top of the page and moving to the bottom:

```
organization:
    name:
    url:
    logo_file:
```
The “organization” key controls the link at the top left: “name” is the displayed text, “logo_file” is the name of the image file to be used (which should be present in /public/images), and “url” is the link target.  Note that in contrast to the diagram, the “BETYdb” portion of the heading is controlled by the next key.

```
site_identification_markup:
```
This takes a free-form value which allows any well-formed HTML markup.  It is the responsibility of the customizer to ensure that the markup works well within the general page layout.

```
homepage_heading:
```
This is just text (currently, "Welcome to BETYdb”).

```
homepage_body:
    lead_text:
    marked_up_block_text:
    photo:
        file:
        alt_text:
```
“lead_text” is just text; it cannot include markup.

“marked_up_block_text" is also text but may include markup.  (The default value includes a `<strong>` tag.)

"photo/file” should be the file name of the photo to use on the home page.  The file must be present in /public/images.

“photo/alt_text” is the text to be shown if the photo file is missing or the user has image display turned off.

#### <b>Top-left footer item (BETYdb)</b>

I have not yet implemented customization of this item.  Should it be linked somehow with the site_identification_markup (`"<strong>BETY</strong>db <small><strong>Biofuel Ecophysiological Traits and Yields </strong>Database</small>”`) or the homepage_heading (`"Welcome to BETYdb”`) or should it be completely independent for maximum flexibility?  I _did_ put the Maps & Data link shown underneath this item under the control of the configuration item that controls the display of the crop maps.

#### <b>Contact items</b>

These were handled previously.  The keys to use are “admin_phone” and “admin_email”.  Should I make the Gitter link configurable as well?

```
footer_background_image_file
```
This is the name of the image file to be displayed above the citation, license, and copyright information.  It must exist in /public/images.

```
citation_license_copyright_markup
```
This free-form text that may include HTML markup.

```
sponsors
```
This is a YAML list of sets of key-value pairs, one set for each sponsor.  Each set should contain the following sub-keys:

-   URL: This should likely be the URL of the sponsor’s Web site.
-   title: This will be available to screen readers.  The text may appear when the user mouses over the link.
-   text: The link text.  This will not be visible but will likely be available to screen readers.
-   logo_file: This is the name of the file containing the sponsor’s logo.  It will normally be the sole visible representation of the link since the link text is hidden.
-   width: This is the width of the link element for which the logo is the background.  It generally should be at least the width of the logo image and at most 440px.

In addition, each set _may_ contain the following key:

-   additional_styling: This should be a (possibly empty) list of CSS declarations (key-value pairs) separated by semicolons.  This is primarily intended as a way of adjusting the layout by setting padding or margins on individual elements.

Note that a YAML list is delimited using a hyphen.  For example, the value of sponsors in `defaults.yml` is
```
sponsors:
    - URL: http://illinois.edu
      title: "University of Illinois at Urbana-Champaign"
      text: "University of Illinois at Urbana-Champaign"
      logo_file: logo-illinois.png
      width: 246px
    - URL: http://www.berkeley.edu
      title: "University of California, Berkeley"
      text: "University of California, Berkeley"
      logo_file: logo-berkeley.png
      width: 145px
      additional_styling: "margin-left: 20%"
    - URL: http://www.lbl.gov
      title: "Lawrence Berkeley National Laboratory (LBL)"
      text: "Lawrence Berkeley National Laboratory"
      logo_file: logo-lbl.png
      width: 232px
    - URL: http://www.bp.com
      title: "British Petroleum (BP)"
      text: "British Petroleum (BP)"
      logo_file: logo-bp.png
      width: 54px
      additional_styling: "margin-right: 40%"
```
The `-` character tells us the set of key-value pairs that follow are for a new, different sponsor.

```
show_crop_map_links:
```
In addition to the above, there is one more key, `show_crop_map_links`, not corresponding to any of the areas indicated in the diagram.  It  controls the display of the links to the crop model maps.  The value is boolean; it should be `true` or `false`.

# Additional notes

The values that have been chosen for the keys in `defaults.yml` are those that will maintain the existing look of the home page on ebi-forecast (except for the contact phone number and e-mail address, which are just dummy values).  If there are values here that most users will not use, perhaps the defaults file should be adjusted accordingly.  For example, if most instances of BETYdb will not be showing the crop model map links, perhaps the default value for `show_crop_map_links` should be `false`, not `true`.  On the other hand, the `defaults.yml` file as is serves as a comprehensive template for the kinds of value possible and expected for each of the keys.

## Overriding default values.

To override the default values supplied in `defaults.yml`, it is recommended that each site have a `config/application.yml` file.  Each top-level key in `defaults.yml` may be overridden by including that key and a corresponding value in `application.yml`.  Note that you cannot override the value of a subkey without supplying a complete new value for the top level key.  For example, if you want to change the name of the logo file used for the organization from the default “logo-ebi.png” to “new-ebi-logo.jpg” but keep the organization name and url the same, you can’t just put

```
organization:
    logo_file: "new-ebi-logo.jpg"
```
You have to repeat the other subkeys with their corresponding values, even though those values are the same as the ones in `defaults.yml`:
```
organization:
  name: "Energy Biosciences Institute"
  url: "/"
  logo_file: “new-ebi-logo.jpg”
```

## The sponsors configuration.

The existing layout was designed with four sponsors in mind.  If more are used, the additional ones may wrap to a new line.  If fewer are used, they may not be centered, though possibly using the "width" and “additional_styling” keys one may be able to compensate for this.  It might be better to change the “sponsors” value to a single free-form text value with markup allowed.  This would allow maximum flexibility but would also put the onus on each individual Web site maintainer for generating the correct HTML code yielding the desired layout.
 