### PR TITLE
Remove CF from standard name field in interface

### DIFF
--- a/app/views/variables/edit.html.erb
+++ b/app/views/variables/edit.html.erb
@@ -15,7 +15,7 @@
             </div>
             <% if current_user.page_access_level==1 %>
             <div class="four columns alpha">
-              <%= f.label :standard_name ,"CF Standard Name"%>
+              <%= f.label :standard_name ,"Standard Name"%>
               <%= f.text_field :standard_name, :class => "input-full" %>
             </div>
             <% end %>
@@ -25,7 +25,7 @@
             </div>
             <% if current_user.page_access_level==1 %>
             <div class="four columns alpha">
-              <%= f.label :standard_units,"CF Standard Units" %>
+              <%= f.label :standard_units,"Standard Units" %>
               <%= f.text_field :standard_units, :class => "input-full" %>
             </div>
             <% end %>

--- a/app/views/variables/new.html.erb
+++ b/app/views/variables/new.html.erb
@@ -14,7 +14,7 @@
               <%= f.text_field :name, :class => "input-full" %>
             </div>
             <div class="four columns alpha">
-              <%= f.label :standard_name ,"CF Standard Name"%>
+              <%= f.label :standard_name ,"Standard Name"%>
               <%= f.text_field :standard_name, :class => "input-full" %>
             </div>
             <div class="four columns alpha">
@@ -22,7 +22,7 @@
               <%= f.text_field :units, :class => "input-full" %>
             </div>
             <div class="four columns alpha">
-              <%= f.label :standard_units,"CF Standard Units" %>
+              <%= f.label :standard_units,"Standard Units" %>
               <%= f.text_field :standard_units, :class => "input-full" %>
             </div>
             <div class="four columns alpha">


### PR DESCRIPTION
Change interface for variables show and edit  so that 'standard_name' is not prepended with 'CF'