### PR TITLE
Implemented a "contains" parameter for the API for filtering sites.

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -70,6 +70,15 @@ class Api::BaseController < ActionController::Base
       end
     end
 
+    if (model == Site) && (params.has_key? "containing")
+      lat_lon_text = params['containing']
+      lat_text, lon_text = lat_lon_text.split(',')
+      lat = lat_text.to_f
+      lon = lon_text.to_f
+
+      model = model.where("ST_CONTAINS(geometry, st_geomfromtext('POINT(#{lon.to_s} #{lat.to_s})', 4326))");
+    end
+
     # Do filtering by regexp matching first.  Note that fuzzy_match_restrictions
     # may modify where_params by removing key-value pairs corresponding to fuzzy
     # matches.


### PR DESCRIPTION
@max-zilla You can test out this implementation if you have your own instance of BETYdb you can pull to.  Otherwise, I'll put it up on one of the test sites.

Try, for example,
```
http://localhost:3000/api/beta/sites?containing=42.7941565,-76.11638
```
if you are using the WEBrick Rails server and have the sites data from `ebi_production`.  Note that the numbers are in the order lat,lon as is conventional.