### PR TITLE
Issue 516 speed up search api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rails3-restful-authentication', '~> 3.0.1'
 gem 'dynamic_form'
 gem 'rabl'
 gem 'yajl-ruby'
+gem 'jbuilder'
 
 # to-do: remove prototype dependencies so we no longer need this gem
 gem 'prototype_legacy_helper', '0.0.0', :git => 'git://github.com/rails/prototype_legacy_helper.git'
@@ -52,7 +53,7 @@ end
 
 
 group :test do
-  # phasing out webrat:    
+  # phasing out webrat:
   # gem "webrat", "0.7.1"
   gem "capybara"
   gem "database_cleaner"
@@ -88,4 +89,3 @@ gem "json-schema" # needed by rspec_api_documentation
 
 gem "apipie-rails"
 gem "test-unit" # seems to be needed by apipie-rails and prototype-rails
-

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'dynamic_form'
 gem 'rabl'
 gem 'yajl-ruby'
 gem 'jbuilder'
+gem 'oj'
 
 # to-do: remove prototype dependencies so we no longer need this gem
 gem 'prototype_legacy_helper', '0.0.0', :git => 'git://github.com/rails/prototype_legacy_helper.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     ffi (1.9.8)
     hike (1.2.3)
     i18n (0.7.0)
+    jbuilder (2.6.4)
+      activesupport (>= 3.0.0)
+      multi_json (>= 1.2)
     journey (1.0.4)
     json (1.8.3)
     json-schema (2.6.1)
@@ -202,6 +205,7 @@ DEPENDENCIES
   comma (= 3.0.4)
   database_cleaner
   dynamic_form
+  jbuilder
   json
   json-schema
   memoist
@@ -234,4 +238,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.14.5
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     narray (0.6.0.4)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    oj (3.3.5)
     passenger (4.0.24)
       daemon_controller (>= 1.1.0)
       rack
@@ -212,6 +213,7 @@ DEPENDENCIES
   multi_json (= 1.3.6)
   narray (= 0.6.0.4)
   nokogiri
+  oj
   passenger
   pg
   prototype-rails

--- a/app/views/api/v1/base/index.json.jbuilder
+++ b/app/views/api/v1/base/index.json.jbuilder
@@ -1,0 +1,79 @@
+json.data @row_set.each do |row|
+
+  view_url = if !row.instance_of?(TraitsAndYieldsView)
+    polymorphic_url(row)
+  else
+    if row.result_type =~ /traits/
+      "#{request.base_url}/traits/#{row.id}"
+    elsif row.result_type =~ /yields/
+      "#{request.base_url}/yields/#{row.id}"
+    end
+  end
+
+  edit_url = if !row.instance_of?(TraitsAndYieldsView)
+    edit_polymorphic_url(row)
+  else
+    if row.result_type =~ /traits/
+      "#{request.base_url}/traits/#{row.id}/edit"
+    elsif row.result_type =~ /yields/
+      "#{request.base_url}/yields/#{row.id}/edit"
+    end
+  end
+
+  children = row.class.reflect_on_all_associations(:belongs_to)
+
+  multiple_associations = row.class.reflect_on_all_associations(:has_many)
+
+  # List of join tables that don't add any useful information
+  excluded_join_tables = [:citation_sites, # excludes citations_sites from both citation and site display
+                          :citation_treatments, # excludes citations_treatments from citation display
+                          :citations_treatments, # excludes citations_treatments from treatment display
+                          :managements_treatments, # excludes managements_treatments from both management and treatment display
+                          :posteriors_ensembles, # this association is not working
+                          :pfts_priors, # excludes pfts_priors from both pfts and priors display
+                          :pfts_species, # excludes pfts_species from both pfts and species display
+                          :sitegroups_sites # excludes sitegroups_sites from sites display
+                         ]
+
+  # Don't display join table information if no useful information is to be had
+  multiple_associations.reject! { |assoc| excluded_join_tables.include?(assoc.name) }
+
+  json.traits_and_yields_view do
+    json.(row, *row.class.column_names.map(&:to_sym))
+    json.view_url view_url
+    json.edit_url edit_url
+
+    case @associations_mode
+    when :count
+      (multiple_associations).each do |assoc|
+        json.set! "number of associated #{assoc.name.to_s}" do
+          begin
+            row.send(assoc.name).size
+          rescue => e
+            Rails.logger.debug("Exception: #{e.message}")
+            Rails.logger.debug("Couldn't send #{assoc.name.inspect} to #{row.inspect}")
+          end
+        end
+      end
+    when :ids
+      (multiple_associations).each do |assoc|
+        json.set! "associated #{assoc.name.to_s.singularize} ids" do
+          begin
+            row.send(assoc.name).map(&:id)
+          rescue => e
+            Rails.logger.debug("Exception: #{e.message}")
+            Rails.logger.debug("Couldn't send #{assoc.name.inspect} to #{row.inspect}")
+          end
+        end
+      end
+    when :full_info
+      (children + multiple_associations).each do |assoc|
+        next if assoc.klass == User
+        json.set! assoc.name do
+          josn.(attributes *assoc.klass.column_names.map(&:to_sym))
+        end
+      end
+    end
+
+  end
+end

--- a/app/views/api/v1/base/index.rabl
+++ b/app/views/api/v1/base/index.rabl
@@ -1,0 +1,8 @@
+collection @row_set
+
+# TO-DO (maybe): Allow a way to override this default value of locals so that
+# :abbreviate_associations can be set to true instead or both
+# :summarize_associations and :abbreviate_associations set to false (to get full
+# association information).  Maybe change from using boolean-valued flags to
+# some 3-valued option.
+extends("api/v1/base/show")

--- a/app/views/api/v1/base/index.rabl
+++ b/app/views/api/v1/base/index.rabl
@@ -1,8 +1,0 @@
-collection @row_set
-
-# TO-DO (maybe): Allow a way to override this default value of locals so that
-# :abbreviate_associations can be set to true instead or both
-# :summarize_associations and :abbreviate_associations set to false (to get full
-# association information).  Maybe change from using boolean-valued flags to
-# some 3-valued option.
-extends("api/v1/base/show")

--- a/app/views/api/v1/base/show.rabl
+++ b/app/views/api/v1/base/show.rabl
@@ -64,9 +64,9 @@ if !root_object.nil?
       polymorphic_url(ob)
     else
       if ob.result_type =~ /traits/
-        trait_url(Trait.find(ob.id))
+        trait_url(ob.id)
       elsif ob.result_type =~ /yields/
-        yield_url(Yield.find(ob.id))
+        yield_url(ob.id)
       end
     end
   end
@@ -77,9 +77,9 @@ if !root_object.nil?
       edit_polymorphic_url(ob)
     else
       if ob.result_type =~ /traits/
-        edit_trait_url(Trait.find(ob.id))
+        edit_trait_url(ob.id)
       elsif ob.result_type =~ /yields/
-        edit_yield_url(Yield.find(ob.id))
+        edit_yield_url(ob.id)
       end
     end
   end

--- a/app/views/layouts/api/base.erb
+++ b/app/views/layouts/api/base.erb
@@ -7,7 +7,7 @@
   if controller.request.format == 'xml'
     data_from_template = Hash.from_xml(yield)
   else # JSON
-    require 'yajl'
+    require 'oj'
     data_from_template = Yajl::Parser.parse(yield)
   end
 
@@ -49,6 +49,6 @@
   if controller.request.format == 'xml'
     raw(data_hash.to_xml)
   else
-    raw(Yajl::Encoder.new(pretty: true).encode(data_hash))
+    raw(Oj.dump(data_hash))
   end
 %>

--- a/app/views/layouts/api/base.erb
+++ b/app/views/layouts/api/base.erb
@@ -30,7 +30,7 @@
 
   # Add data from index or show template if those actions were called:
   if !@row_set.nil? || !@row.nil?
-    data_hash[:data] = data_from_template
+    data_hash.merge!(data_from_template)
   end
 
   # Don't show extraneous keys--just delete if the value is empty:


### PR DESCRIPTION
Speed up search api more than 3 times

On start search api takes on my local machine 3200ms on 1k limit.

- On first i fix n+1 on 'trait/yield' links. It speed up request from 3200ms to 2700ms on 1k limit

- The second step is change rabl json template on jbuilder it speed up request from 2700ms to 2200ms

- The third step is changing forming 'trait/yield' links from rails routes to string, it looks a little dirty but speed up from 2200ms to 1900ms

- The last step is change yajl serializer to oj for search api, it speed up from 1900ms to 1000ms

Now in my local machine search api request with limit=1000 gets 1000ms