### PR TITLE
Fixed setval calls in migrations.

### DIFF
--- a/db/migrate/20160412030352_add_sitegroups.rb
+++ b/db/migrate/20160412030352_add_sitegroups.rb
@@ -13,7 +13,7 @@ class AddSitegroups < ActiveRecord::Migration
     change_column :sitegroups, :id, :integer, :limit => 8
     # fix the counter for inserting new records
     execute %{
-        SELECT setval('sitegroups_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+        SELECT setval('sitegroups_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
         ALTER TABLE sitegroups
             ALTER COLUMN created_at SET DEFAULT utc_now(),
             ALTER COLUMN updated_at SET DEFAULT utc_now(),
@@ -31,7 +31,7 @@ class AddSitegroups < ActiveRecord::Migration
     change_column :sitegroups_sites, :id, :integer, :limit => 8
     # fix the counter for inserting new records and add foreign key constraints
     execute %{
-        SELECT setval('sitegroups_sites_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+        SELECT setval('sitegroups_sites_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
         ALTER TABLE sitegroups_sites
             ALTER COLUMN created_at SET DEFAULT utc_now(),
             ALTER COLUMN updated_at SET DEFAULT utc_now();

--- a/db/migrate/20160617133217_add_id_to_table.rb
+++ b/db/migrate/20160617133217_add_id_to_table.rb
@@ -4,9 +4,9 @@ class AddIdToTable < ActiveRecord::Migration
 
     execute %{
       ALTER TABLE "cultivars_pfts" ADD "id" bigserial;
-      SELECT setval('cultivars_pfts_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('cultivars_pfts_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "trait_covariate_associations" ADD "id" bigserial;
-      SELECT setval('trait_covariate_associations_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('trait_covariate_associations_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
     }
   end
 

--- a/db/migrate/20160711231257_create_benchmarks_tables.rb
+++ b/db/migrate/20160711231257_create_benchmarks_tables.rb
@@ -17,7 +17,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('benchmarks_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmarks_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmarks"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -43,7 +43,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('metrics_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('metrics_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "metrics"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -58,7 +58,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('reference_runs_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('reference_runs_id_seq', 1 + GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "reference_runs"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -77,7 +77,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('benchmark_sets_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmark_sets_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmark_sets"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -94,7 +94,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('benchmarks_ensembles_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmarks_ensembles_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmarks_ensembles"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -120,7 +120,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.timestamps
     end
     execute %{
-      SELECT setval('benchmarks_ensembles_scores_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmarks_ensembles_scores_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmarks_ensembles_scores"
       ALTER COLUMN created_at SET DEFAULT utc_now(),
       ALTER COLUMN updated_at SET DEFAULT utc_now();
@@ -142,7 +142,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.integer :metric_id, :limit => 8
     end
     execute %{
-      SELECT setval('benchmarks_metrics_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmarks_metrics_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmarks_metrics"
       ADD CONSTRAINT "benchmarks_metrics_benchmark_id_fkey" 
         FOREIGN KEY ("benchmark_id") REFERENCES benchmarks("id")
@@ -158,7 +158,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.integer :reference_run_id, :limit => 8
     end
     execute %{
-      SELECT setval('benchmarks_benchmarks_reference_runs_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmarks_benchmarks_reference_runs_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmarks_benchmarks_reference_runs"
       ADD CONSTRAINT "benchmarks_benchmarks_reference_runs_benchmark_id_fkey" 
         FOREIGN KEY ("benchmark_id") REFERENCES benchmarks("id")
@@ -174,7 +174,7 @@ class CreateBenchmarksTables < ActiveRecord::Migration
       t.integer :reference_run_id, :limit => 8
     end  
     execute %{
-      SELECT setval('benchmark_sets_benchmark_reference_runs_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('benchmark_sets_benchmark_reference_runs_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE "benchmark_sets_benchmark_reference_runs"
       ADD CONSTRAINT "benchmark_sets_benchmark_reference_runs_benchmark_set_id_fkey" 
         FOREIGN KEY ("benchmark_set_id") REFERENCES benchmark_sets("id")

--- a/db/migrate/20170118205944_set_experiment_table_id_seq_vals.rb
+++ b/db/migrate/20170118205944_set_experiment_table_id_seq_vals.rb
@@ -3,9 +3,9 @@ class SetExperimentTableIdSeqVals < ActiveRecord::Migration
     this_hostid = Machine.new.hostid
 
     execute %{
-      SELECT setval('experiments_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
-      SELECT setval('experiments_sites_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
-      SELECT setval('experiments_treatments_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('experiments_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('experiments_sites_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('experiments_treatments_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
       ALTER TABLE experiments_sites ADD CONSTRAINT unique_experiment_site_pair UNIQUE (experiment_id, site_id);
       ALTER TABLE experiments_treatments ADD CONSTRAINT unique_experiment_treatment_pair UNIQUE (experiment_id, treatment_id);
     }

--- a/db/migrate/20170712171513_sites_cultivars_uniqueness.rb
+++ b/db/migrate/20170712171513_sites_cultivars_uniqueness.rb
@@ -3,7 +3,7 @@ class SitesCultivarsUniqueness < ActiveRecord::Migration
     this_hostid = Machine.new.hostid
 
     execute %{
-      SELECT setval('sites_cultivars_id_seq', GREATEST(1, CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
+      SELECT setval('sites_cultivars_id_seq', GREATEST(1, 1 + CAST(1e9 * #{this_hostid}::int AS bigint)), FALSE);
 
       ALTER TABLE sites_cultivars ADD CONSTRAINT unique_site_id UNIQUE (site_id);
     }


### PR DESCRIPTION
This fix makes numbering start at `machine_id x 1000000000 + 1` instead of at `machine_id x 1000000000`.  This is important because the sync script will not import rows with ids of the form `machine_id x 1000000000`.

In general, there is probably not much utility in fixing "old" migrations—it is probably mainly developers who would be using anything other than the latest migrations.  In this case, however, correcting the migrations serves a documentary purpose: if future migration writers want to see how `setval` should be used to set the initial id sequence values, it is important to have a correct model to use as an example.

I discovered this problem when I noticed several dangling foreign-key references having to do with the `experiments` table.  In particular, the `experiments` row with id 6000000000 is often referred to in other tables, but the sync script does not import this row from machine 6.  Rows with this id need to be renumbered, and the foreign keys that refer to them need to be updated accordingly.