### PR TITLE
Add maps.js to the precompile list to fix issue 596.

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,6 +17,8 @@ Rails.application.config.assets.precompile += %w(
   lazy/feedback.js
   lazy/autocomplete.js
   lazy/bulk_upload.js
+
+  mylibs/maps.js
  )
 
 Rails.application.config.assets.paths <<


### PR DESCRIPTION
Fixes issue 596, a problem with the crop model maps (applies to EBI and TERRA-MEPP sites only).