### PR TITLE
Fix covariate page issues

### DIFF
--- a/app/controllers/covariates_controller.rb
+++ b/app/controllers/covariates_controller.rb
@@ -31,6 +31,10 @@ class CovariatesController < ApplicationController
   def show
     @covariate = Covariate.find(params[:id])
 
+    if @covariate.trait.nil?
+      flash[:error] = 'This covariated is not associated with a trait!  Consider removing it.'
+    end
+
     respond_to do |format|
       format.html # show.html.erb
       format.xml  { render :xml => @covariate }

--- a/app/views/covariates/edit.html.erb
+++ b/app/views/covariates/edit.html.erb
@@ -44,17 +44,14 @@
           <%= f.label :statname %><br />
           <%= f.select :statname, $statname_list %>
         </p>
-        <p>
-          <%= f.submit 'Update' %>
-        </p>
 
         <div class="form-actions">
           <div class="button-group">
             <%= link_to( covariates_path ) do %>
-              <button class="button"><i class="icon-arrow-left"></i> All Records</button>
+              <button class="button" type="button"><i class="icon-arrow-left"></i> All Records</button>
             <% end %>
             <%= link_to( @covariate ) do %>
-              <button class="button">Show</button>
+              <button class="button" type="button">Show</button>
             <% end %>
           </div>
           <div class="button-group pull-right">

--- a/app/views/covariates/show.html.erb
+++ b/app/views/covariates/show.html.erb
@@ -18,6 +18,7 @@
     <dd><%= @covariate.stat %></dd>
     <dt>Statname:</dt>
     <dd><%= @covariate.statname %></dd>
+    <% if @covariate.trait %>
     <dt>Associated Trait:</dt>
     <dd>
       <%= link_to_if @covariate.trait, @covariate.trait, @covariate.trait %>
@@ -32,6 +33,7 @@
     <dd><%= link_to_if @covariate.trait.specie, @covariate.trait.specie, @covariate.trait.specie %></dd>
     <dt>Citation:</dt>
     <dd><%= link_to_if @covariate.trait.citation, @covariate.trait.citation, @covariate.trait.citation %></dd>
+    <% end %>
   </dl>
 
 


### PR DESCRIPTION
Added a "type" attribute to the "Show" and "All Records" buttons on the covariate editing pages to prevent the default "submit" action from being
attempted.  This fixes issue #585.  Also removed an extraneous "Update" button.

Make the "Show" page for covariates give a more user-friendly error message when
the covariate lacks an association with a trait.