### PR TITLE
Modify site soil choices

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -269,7 +269,7 @@ CONDITION
     @soil_classes ||= ['clay', 'clay loam', 'loam', 'loamy sand', 'sand',
                        'sandy clay', 'sandy clay loam', 'sandy loam',
                        'silt', 'silt loam', 'silty clay', 'silty clay loam',
-                       'peat', 'bedrock', 'other']
+                       'peat', 'bedrock', 'other'].freeze
   end
 
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -231,7 +231,7 @@ CONDITION
 
   def sitename_state_country
     output = ""
-    
+
     #city = city.chomp if !city.nil?
     if !sitename.blank?
       output += "#{sitename}"
@@ -261,6 +261,17 @@ CONDITION
   def autocomplete_label
     "#{sitename.squish} (#{city.squish}, #{!(state.nil? || state.empty?) ? " #{state.squish}," : ""} #{country.squish})"
   end
+
+  ### Class methods
+
+  def self.soil_classes
+
+    @soil_classes ||= ['clay', 'clay loam', 'loam', 'loamy sand', 'sand',
+                       'sandy clay', 'sandy clay loam', 'sandy loam',
+                       'silt', 'silt loam', 'silty clay', 'silty clay loam',
+                       'peat', 'bedrock', 'other']
+  end
+
 
   private
 

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -311,7 +311,7 @@
             <%= f.label :lon %>
             <%= geometry_aware_text_field(f, :lon, { class: "input-full" }) %>
             <%= f.label :soil %>
-            <%= f.select :soil, %w(sandloamy sandsandy loamsilt loamloamsandy clay loamsilty clay loamclay loamsandy claysilty clayclaypeat), { :include_blank => true }, :class => "input-full" %>
+            <%= f.select :soil, Site.soil_classes, { :include_blank => true }, :class => "input-full" %>
             
             <div class="two columns alpha">
               <%= f.label :clay_pct, "% Clay" %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -309,7 +309,7 @@
             <%= f.text_field :lon, :class => "input-full" %>
             <br /><br />
             <%= f.label :soil %>
-            <%= f.select :soil, %w(sandloamy sandsandy loamsilt loamloamsandy clay loamsilty clay loamclay loamsandy claysilty clayclaypeat), { :include_blank => true }, :class => "input-full" %>
+            <%= f.select :soil, Site.soil_classes, { :include_blank => true }, :class => "input-full" %>
             
             <div class="two columns alpha">
               <%= f.label :clay_pct, "% Clay" %>


### PR DESCRIPTION
I used the 12 USDA types (in alphabetical order) followed by `peat`, `bedrock`, and `other` (in that order).  That is, this is the order the soil classes will appear in the `Soil` dropdown in the forms on the Site creation and modification pages.  The order could be changed if desired.

This change set addresses issue #652 .