### PR TITLE
Changed links to BETYdb data-entry and technical guides to point to bookdown versions.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -200,9 +200,9 @@
 
             <li class="menu-docs"> <a>Docs</a>
               <ul class="sub-menu">
-                <li><%= link_to "Data Entry", "https://pecan.gitbooks.io/betydbdoc-dataentry/content/", :target =>"_blank" %></li>
+                <li><%= link_to "Data Entry", "https://pecanproject.github.io/bety-documentation/dataentry/", :target =>"_blank" %></li>
                 <li><%= link_to "Data Access", "https://pecan.gitbooks.io/betydb-data-access/content/", :target =>"_blank" %>></li>
-                <li><%= link_to "Implementation", "https://pecan.gitbooks.io/betydb-documentation/content/", :target =>"_blank" %></li>
+                <li><%= link_to "Implementation", "https://pecanproject.github.io/bety-documentation/technical", :target =>"_blank" %></li>
                 <li><%= link_to "Schema", schemas_path %>></li>
               </ul>
             </li>


### PR DESCRIPTION
This relates to https://github.com/PecanProject/betydb-documentation/issues/10 and issue #653.