### PR TITLE
HOT FIX for Bulk Upload method specification problem

### DIFF
--- a/app/controllers/bulk_upload_controller.rb
+++ b/app/controllers/bulk_upload_controller.rb
@@ -121,7 +121,7 @@ class BulkUploadController < ApplicationController
       method_name: params["method_info"]["label"],
       method_id: params["method_info"]["value"]
     }
-    render(nothing: true)
+    render(body: nil)
   end
 
   # Step 1: Choose a file to upload.


### PR DESCRIPTION
This fixes the bug mentioned in this issue: https://github.com/az-digitalag/organization/issues/12

The bug was introduced by the upgrade to Rails 5.1, which no longer supports "render nothing: true".  (See, e.g., https://stackoverflow.com/questions/34688726/the-nothing-option-is-deprecated-and-will-be-removed-in-rails-5-1.)