### PR TITLE
Update capybara webkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    capybara-webkit (1.15.0)
+    capybara-webkit (1.15.1)
       capybara (>= 2.3, < 4.0)
       json
     childprocess (0.9.0)
@@ -298,3 +298,6 @@ DEPENDENCIES
   will_paginate
   yajl-ruby (~> 1.3.1)
   yard
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
We solved the Travis build problem by filtering this Gem out, but since version 1.15.0 no longer installs successfully on my work station, it makes sense to update the Gemfile version.