### PR TITLE
Fix citation controller's show method

### DIFF
--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -123,7 +123,10 @@ class CitationsController < ApplicationController
   # GET /citations/1
   # GET /citations/1.xml
   def show
-    @citation = Citation.where(:id => params[:id]).includes(params[:include]).first
+    # find_by! throws an ActiveRecord::RecordNotFound exception if no citation
+    # with the given id exists so that we don't attempt to display a nil
+    # citation.
+    @citation = Citation.includes(params[:include]).find_by!(:id => params[:id])
 
     respond_to do |format|
       format.html # show.html.erb


### PR DESCRIPTION
Make the citation controller's "show" action throw an ActiveRecord::RecordNotFound exception when the given model is not found, just as all the other controllers do.

This fixes issue #668.