### PR TITLE
Fix for issue 672 (XML endpoints no longer working)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'protected_attributes_continued' # Use this until and unless we start using 
 gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'
+gem 'activemodel-serializers-xml' # no longer part of Rails proper as of Rails 5
 
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.1.5)
       activesupport (= 5.1.5)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (5.1.5)
       activemodel (= 5.1.5)
       activesupport (= 5.1.5)
@@ -251,6 +255,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activemodel-serializers-xml
   activerecord-postgis-adapter
   activerecord-session_store
   apipie-rails (= 0.5.6)


### PR DESCRIPTION
Adding Gem to restore XML functions that are no longer part of Rails proper as of version 5.