### PR TITLE
set default show_crop_map_links: false

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -92,7 +92,7 @@ homepage_body:
 # Miscellaneous
 
 ## This affects both the home page and the footer:
-show_crop_map_links: true
+show_crop_map_links: false
 
 # Override this with a secret key to run a secure site:
 rest_auth_site_key: 'thisisnotasecret'


### PR DESCRIPTION
in defaults.yml

1. this should be off by default; they were only relevant to BETYdb.org
2. Google has deprecated Fusiontables that these maps use; easiest fix is not to show them. No longer a priority mandated by EBI