### PR TITLE
make ActionMailer use sendmail binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ In this case you can simply pull down the version you want, and run `docker-comp
 - Fixes to the docker build to fit in kubernetes helm chart.
 - Added Wisconsin back to database dump workflow
 - Catch exception when load.bety fails and cleans up /tmp folder
+- Fix problem with sendmail causing error on new user sign up https://github.com/PecanProject/bety/issues/677
 
 ### Changed
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,11 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  
+  # ActionMailer use the sendmail binary directly.
+  # Fixes https://github.com/PecanProject/bety/issues/677
+
+  config.action_mailer.delivery_method = :sendmail
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
* Fixes #677 
* see https://www.nico.schottelius.org/blog/ruby-on-rails-fix-hostname-does-not-match-the-server-certificate/