### PR TITLE
Allow the JavaScript variable ROOT_URL to be initialized to a the value of a Rails config variable.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,7 +84,7 @@ end
 # ```
 # <% content_for(:autocomplete_javascript) do %>
 #     <script type="text/javascript" charset="utf-8">
-#         var ROOT_URL = '<%= root_url %>';
+#         var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
 #         var completion_fields = {
 #             <id of autocompletion field>: {
 #                 controller:

--- a/app/views/bulk_upload/choose_global_citation.html.erb
+++ b/app/views/bulk_upload/choose_global_citation.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:autocomplete_javascript) do %>
   <!-- bulk_upload.js needs to know the root -->
-  <script type="text/javascript" charset="utf-8">var ROOT_URL = '<%= root_url %>';</script>
+  <script type="text/javascript" charset="utf-8">var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';</script>
   <%= javascript_include_tag 'lazy/bulk_upload.js' %>
 <% end %>
 <div class="content">

--- a/app/views/bulk_upload/choose_global_data_values.html.erb
+++ b/app/views/bulk_upload/choose_global_data_values.html.erb
@@ -2,9 +2,9 @@
   <!-- bulk_upload.js needs to know the root -->
   <script type="text/javascript" charset="utf-8">
   //<![CDATA[
-    /* bulk_upload.js expects root_url and bu_completion_fields to be set. */
+    /* bulk_upload.js expects ROOT_URL and bu_completion_fields to be set. */
 
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
 
     <%
        bu_completion_field_hash = {}

--- a/app/views/covariates/edit.html.erb
+++ b/app/views/covariates/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_variables": { controller: "variables",
                         hidden_field_id: "covariate_variable_id" }

--- a/app/views/formats/edit.html.erb
+++ b/app/views/formats/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_mimetypes": { controller: "mimetypes",
                             hidden_field_id: "form_mimetype_id" }

--- a/app/views/formats/new.html.erb
+++ b/app/views/formats/new.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_mimetypes": { controller: "mimetypes",
                             hidden_field_id: "form_mimetype_id" }

--- a/app/views/inputs/edit.html.erb
+++ b/app/views/inputs/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_sites": { controller: "sites",
                         hidden_field_id: "input_site_id" },

--- a/app/views/inputs/new.html.erb
+++ b/app/views/inputs/new.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_sites": { controller: "sites",
                         hidden_field_id: "input_site_id" },

--- a/app/views/methods/edit.html.erb
+++ b/app/views/methods/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_citations": { controller: "citations",
                             // Because the model name is Methods (plural) and

--- a/app/views/methods/new.html.erb
+++ b/app/views/methods/new.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_citations": { controller: "citations",
                             // Because the model name is Methods (plural) and

--- a/app/views/priors/edit.html.erb
+++ b/app/views/priors/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_citations": { controller: "citations",
                         hidden_field_id: "prior_citation_id" },

--- a/app/views/priors/new.html.erb
+++ b/app/views/priors/new.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_citations": { controller: "citations",
                         hidden_field_id: "prior_citation_id" },

--- a/app/views/traits/edit.html.erb
+++ b/app/views/traits/edit.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_variables": { controller: "variables",
                         hidden_field_id: "trait_variable_id" }

--- a/app/views/traits/new.html.erb
+++ b/app/views/traits/new.html.erb
@@ -2,7 +2,7 @@
   <!-- autocomplete.js needs a `completion_fields` object describing the
   autocompletion fields on the page and needs to know the Rails root -->
   <script type="text/javascript" charset="utf-8">
-    var ROOT_URL = '<%= root_url %>';
+    var ROOT_URL = '<%= CONFIG[:root_url] || root_url %>';
     var completion_fields = {
       "search_variables": { controller: "variables",
                         hidden_field_id: "trait_variable_id" }

--- a/config/application.yml.template
+++ b/config/application.yml.template
@@ -1,4 +1,14 @@
 # All Settings
+
+## Most sites won't need to set this because the URL helper "root_url"
+## (which is the fallback if this config variable isn't set) gets set
+## to the correct path.  The only known case where things fall apart
+## is when a proxy server to a Docker instance of BETYdb redirects
+## HTTP requests to HTTPS.  The Docker instance sets root_url to a URL
+## having the HTTP protocol, and for XHRs, the browser blocks the
+## request before the server has a chance to rewrite it.
+root_url: https://example.com/betyroot
+
 organization:
   name: "My Organization Name"
   url: #{root_path}


### PR DESCRIPTION
Now, instead of simply setting it to the value of the Rails
"root_url" URL helper, the assignment statements first check if the
config variable "root_url" is set and use the value of that if it is,
using the URL helper only as a fallback.

This is an attempt to fix a problem with the CABBI BETYdb instance, which is served using an Apache server as a proxy to a Docker BETYdb instance.  The proxy server rewrites HTTP requests to HTTPS requests.  But this doesn't work for XHRs, and in the Docker instance, the "root_url" URL helper (which is used to initialize the JavaScript variable ROOT_URL) uses the HTTP protocol.  We would like to be able to set the ROOT_URL explicitly to the correct HTTPS URL using a config variable in the customization file `application.yml`.

[A possible alternative to this solution is to use relative paths, setting ROOT_URL to either '..' or '../..', depending on the path to the file setting it.]