### PR TITLE
Splitting input files in load.bety.sh

### DIFF
--- a/script/load.bety.sh
+++ b/script/load.bety.sh
@@ -80,6 +80,12 @@ GUESTUSER=${GUESTUSER:-"NO"}
 # additional options for curl
 CURL_OPTS=${CURL_OPTS:-""}
 
+# additional options for splitting large files
+# Maximum size before splitting
+SPLIT_FILE_MAX=${SPLIT_FILE_MAX:-200000}
+# Size of split files
+SPLIT_FILE_SIZE=${SPLIT_FILE_SIZE:-10000}
+
 # Log file
 LOG=${LOG:-"$PWD/dump/sync.log"}
 
@@ -92,6 +98,9 @@ while getopts a:cd:efghkl:m:o:p:qr:tuw: opt; do
   case $opt in
   a)
     PG_USER="$OPTARG"
+    ;;
+  b)
+    SPLIT_FILE_MAX="$OPTARG"
     ;;
   c)
     CREATE="YES"
@@ -109,8 +118,9 @@ while getopts a:cd:efghkl:m:o:p:qr:tuw: opt; do
     GUESTUSER="YES"
     ;;
   h)
-    echo "$0 [-a postgres] [-c] [-d database] [-e] [-f] [-g] [-h] [-l logfile] [-m my siteid] [-o owner] [-p psql options] [-r remote siteid] [-t] [-u]"
+    echo "$0 [-a postgres] [-b split max] [-c] [-d database] [-e] [-f] [-g] [-h] [-l logfile] [-m my siteid] [-o owner] [-p psql options] [-r remote siteid] [-s split size] [-t] [-u]"
     echo " -a access database as this user, this is NOT the owner of the database, often this is postgres"
+    echo " -b maximum input lines before input file is split, default $SPLIT_FILE_MAX lines (see -s)"
     echo " -c create database, THIS WILL ERASE THE CURRENT DATABASE, default is NO"
     echo " -d database, default is bety"
     echo " -e empty database, default is NO"
@@ -124,6 +134,7 @@ while getopts a:cd:efghkl:m:o:p:qr:tuw: opt; do
     echo " -p additional psql command line options, default is empty"
     echo " -q should the import be quiet"
     echo " -r remote site id, default is 0 (EBI)"
+    echo " -s split lines per file, default $SPLIT_FILE_SIZE lines (when splitting input files) (see -b)"
     echo " -t keep temp folder, default is NO"
     echo " -u create carya users, this will create some default users"
     echo " -w use url to fetch data from instead of hardcoded url"
@@ -149,6 +160,9 @@ while getopts a:cd:efghkl:m:o:p:qr:tuw: opt; do
     ;;
   r)
     REMOTESITE="$OPTARG"
+    ;;
+  s)
+    SPLIT_FILE_SIZE="$OPTARG"
     ;;
   t)
     KEEPTMP="YES"
@@ -404,7 +418,26 @@ for T in ${EMPTY_TABLES} ${CLEAN_TABLES} ${CHECK_TABLES} ${MANY_TABLES}; do
     echo "SELECT COUNT(*) FROM ${T};" >&3 && read START <&4
     if [[ "${EMPTY}" == "NO" || ${EMPTY_TABLES} == *"$T"* ]]; then
       if [ -f "${DUMPDIR}/${T}.csv" ]; then
-        echo "\COPY ${T} FROM '${DUMPDIR}/${T}.csv' WITH (DELIMITER '	',  NULL '\\N', ESCAPE '\\', FORMAT CSV, ENCODING 'UTF-8')" >&3
+	T_SIZE=`cat ${DUMPDIR}/${T}.csv | wc -l`
+	if [ "${T_SIZE}" -gt "${SPLIT_FILE_MAX}" ]; then
+	  if [ "${QUIET}" != "YES" ]; then
+	    echo "splitting input ${DUMPDIR}/${T}.csv"
+	  fi
+	  RES=`pushd ${DUMPDIR} && split -d -a 4 --additional-suffix=.csv -l ${SPLIT_FILE_SIZE} ${DUMPDIR}/${T}.csv ${T} && popd`
+	  IDX=0
+	  FOUND=true
+	  while [ "${FOUND}" = true ]; do
+	    SPLIT_FILE=`VAL=${IDX} ; printf -v VAL "${DUMPDIR}/${T}%04d.csv" $VAL; echo ${VAL}`
+	    if [ -e "${SPLIT_FILE}" ]; then
+              echo "\COPY ${T} FROM '${SPLIT_FILE}' WITH (DELIMITER '	',  NULL '\\N', ESCAPE '\\', FORMAT CSV, ENCODING 'UTF-8')" >&3
+	    else
+	      FOUND=false
+	    fi
+	    IDX=$((IDX+1))
+	  done
+	else
+          echo "\COPY ${T} FROM '${DUMPDIR}/${T}.csv' WITH (DELIMITER '	',  NULL '\\N', ESCAPE '\\', FORMAT CSV, ENCODING 'UTF-8')" >&3
+	fi
       fi
     fi
     echo "SELECT COUNT(*) FROM ${T};" >&3 && read END <&4

--- a/script/load.bety.sh
+++ b/script/load.bety.sh
@@ -431,7 +431,7 @@ for T in ${EMPTY_TABLES} ${CLEAN_TABLES} ${CHECK_TABLES} ${MANY_TABLES}; do
 	T_SIZE=`cat ${DUMPDIR}/${T}.csv | wc -l`
 	if [ "${T_SIZE}" -gt "${SPLIT_FILE_MAX}" ]; then
 	  if [ "${QUIET}" != "YES" ]; then
-	    echo "splitting input ${DUMPDIR}/${T}.csv - ${T_SIZE} lines (${SPLIT_FILE_MAX} limit, ${SPLIT_FILE_SIZE} split lines)"
+	    echo "splitting input ${DUMPDIR}/${T}.csv - ${T_SIZE} lines (${SPLIT_FILE_MAX} limit, ${SPLIT_FILE_SIZE} per split)"
 	  fi
 	  PREV_SPLIT="${T}"
 	  RES=`pushd ${DUMPDIR} && split -d -a 4 --additional-suffix=.csv -l ${SPLIT_FILE_SIZE} ${DUMPDIR}/${T}.csv ${T} && popd`


### PR DESCRIPTION
Large files on underpowered machines can cause the to appear to database to hang through locking conflicts. One cause is that loading large files in one go uses significant resources, slowing the loading process down. Breaking large source files apart and loading them in a loop resolves this issue