### PR TITLE
Update ci.yml to fix broken build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install libraries


### PR DESCRIPTION
update to ruby/setup-ruby

per message in broken build https://github.com/PecanProject/bety/actions/runs/4521577229/jobs/7963396670

```
Run actions/setup-ruby@v1
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
```