### PR TITLE
[WIP] Add ruby 2.7 to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         ruby: 
           - 2.5
           - 2.6
-          # - 2.7 is not supported, results in error
+          - 2.7 is not supported, results in error
     services:
       postgres:
         image: mdillon/postgis:9.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
@@ -75,6 +75,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/
+      @v2
       - name: Build image
         run: docker build --tag image --file Dockerfile .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/@v2
+      - uses: actions/checkout@v3
       - name: Build image
         run: docker build --tag image --file Dockerfile .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         ruby: 
           - 2.5
           - 2.6
-          - 2.7 is not supported, results in error
+          - 2.7
     services:
       postgres:
         image: mdillon/postgis:9.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/
-      @v2
+      - uses: actions/@v2
       - name: Build image
         run: docker build --tag image --file Dockerfile .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby: 
-          - 2.5
-          - 2.6
           - 2.7
     services:
       postgres:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 LABEL maintainer="Max Burnette <mburnet2@illinois.edu>, Rob Kooper <kooper@illinois.edu>"
 
 # arguments that are added at the bottom of BETY


### PR DESCRIPTION
2.5 and 2.6 have hit EOL. 
2.7 build is successful. This can be merged 

But, should we remove 2.5 and 2.6 from the build since they have reached EOL? 

And update the docker image to use 2.7?